### PR TITLE
chore: 공통 응답 포맷 작성

### DIFF
--- a/src/main/java/com/org/candoit/global/response/ApiResponse.java
+++ b/src/main/java/com/org/candoit/global/response/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.org.candoit.global.response;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final String code;
+    private final String message;
+    private T data;
+
+    public ApiResponse(String code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+    public ApiResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(String.valueOf(HttpStatus.OK.value()), "success", data);
+    }
+
+    public static <T> ApiResponse<T> successWithoutData() {
+        return new ApiResponse<>(String.valueOf(HttpStatus.OK.value()), "success");
+    }
+
+    public static <T> ApiResponse<T> fail(ErrorCode errorCode) {
+        return new ApiResponse<>(errorCode.getCode(), errorCode.getMessage(), null);
+    }
+}

--- a/src/main/java/com/org/candoit/global/response/CustomException.java
+++ b/src/main/java/com/org/candoit/global/response/CustomException.java
@@ -1,0 +1,15 @@
+package com.org.candoit.global.response;
+
+public class CustomException extends RuntimeException{
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/org/candoit/global/response/ErrorCode.java
+++ b/src/main/java/com/org/candoit/global/response/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.org.candoit.global.response;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"10000", "서버 내부 오류입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/global/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/org/candoit/global/response/GlobalExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.org.candoit.global.response;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(annotations = {RestController.class}, basePackages = {"com.org.candoit.domain"})
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiResponse.fail(errorCode));
+    }
+
+    @ExceptionHandler(RuntimeException.class)
+    public ResponseEntity<ApiResponse<?>> handleRuntimeException(RuntimeException e) {
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity
+            .status(errorCode.getHttpStatus())
+            .body(ApiResponse.fail(errorCode));
+    }
+}


### PR DESCRIPTION
## 📌이슈 번호
- #2 

## 👩🏻‍💻구현 내용
- global/response 디렉토리 생성
- 공통 응답 포맷으로 출력할 수 있도록 ApiResponse 작성
- 커스텀 예외를 던질 수 있도록 CustomException 작성
- ErrorCode를 작성. 이후, 도메인 별 ErrorCode를 작성할 계획. 현재는 공통적으로 사용할 수 있는 INTERNAL_SERVER_ERROR만 넣어둠.
- throw Exception을 했을 때, 공통된 포맷으로 출력할 수 있도록 `GlobalExceptionHandler`를 작성