### PR TITLE
feature: 마이페이지 조회 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
+++ b/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
@@ -2,10 +2,12 @@ package com.org.candoit.domain.member.controller;
 
 import com.org.candoit.domain.member.dto.MemberCheckRequest;
 import com.org.candoit.domain.member.dto.MemberJoinRequest;
+import com.org.candoit.domain.member.dto.MyPageResponse;
 import com.org.candoit.domain.member.service.MemberService;
 import com.org.candoit.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,6 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(){
+        MyPageResponse myPageResponse = memberService.getMyPage(4l);
+        return ResponseEntity.ok(ApiResponse.success(myPageResponse));
+    }
 
     @PostMapping("/join")
     public ResponseEntity<ApiResponse<Object>> join(@RequestBody MemberJoinRequest memberJoinRequest){

--- a/src/main/java/com/org/candoit/domain/member/dto/MyPageResponse.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/MyPageResponse.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class MyPageResponse {
+
+    private String profile_image;
+    private String comment;
+    private String email;
+    private String nickname;
+}

--- a/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
@@ -1,0 +1,17 @@
+package com.org.candoit.domain.member.exception;
+
+import com.org.candoit.global.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "00000", "사용자를 찾지 못했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -2,10 +2,12 @@ package com.org.candoit.domain.member.service;
 
 import com.org.candoit.domain.member.dto.MemberCheckRequest;
 import com.org.candoit.domain.member.dto.MemberJoinRequest;
+import com.org.candoit.domain.member.dto.MyPageResponse;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.exception.MemberErrorCode;
 import com.org.candoit.domain.member.repository.MemberRepository;
 import com.org.candoit.global.response.CustomException;
-import com.org.candoit.global.response.ErrorCode;
+import com.org.candoit.global.response.GlobalErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +23,7 @@ public class MemberService {
 
         Member saveRequestMember = Member.builder()
             .email(memberJoinRequest.getEmail())
+            .comment("안녕하세요.")
             .password(memberJoinRequest.getPassword())
             .nickname(memberJoinRequest.getNickname())
             .build();
@@ -38,7 +41,20 @@ public class MemberService {
         }else if(type.equals("email")){
             return memberRepository.findByEmail(content).isPresent();
         }else {
-            throw new CustomException(ErrorCode.BAD_REQUEST);
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
         }
+    }
+
+    public MyPageResponse getMyPage(Long memberId){
+
+        Member member = memberRepository.findById(memberId).orElseThrow(()->new CustomException(
+            MemberErrorCode.NOT_FOUND_MEMBER));
+
+        return MyPageResponse.builder()
+            .profile_image(member.getProfilePath())
+            .comment(member.getComment())
+            .email(member.getEmail())
+            .nickname(member.getNickname())
+            .build();
     }
 }

--- a/src/main/java/com/org/candoit/global/response/ErrorCode.java
+++ b/src/main/java/com/org/candoit/global/response/ErrorCode.java
@@ -1,17 +1,10 @@
 package com.org.candoit.global.response;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+
 import org.springframework.http.HttpStatus;
-import org.springframework.web.client.HttpClientErrorException.BadRequest;
 
-@Getter
-@AllArgsConstructor
-public enum ErrorCode {
+public interface ErrorCode {
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"10000", "서버 내부 오류입니다."),
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "10001", "잘못된 요청입니다.");
-
-    private final HttpStatus httpStatus;
-    private final String code;
-    private final String message;
+    HttpStatus getHttpStatus();
+    String getCode();
+    String getMessage();
 }

--- a/src/main/java/com/org/candoit/global/response/GlobalErrorCode.java
+++ b/src/main/java/com/org/candoit/global/response/GlobalErrorCode.java
@@ -1,0 +1,17 @@
+package com.org.candoit.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"10000", "서버 내부 오류입니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "10001", "잘못된 요청입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/global/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/org/candoit/global/response/GlobalExceptionHandler.java
@@ -19,7 +19,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ApiResponse<?>> handleRuntimeException(RuntimeException e) {
-        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        ErrorCode errorCode = GlobalErrorCode.INTERNAL_SERVER_ERROR;
         return ResponseEntity
             .status(errorCode.getHttpStatus())
             .body(ApiResponse.fail(errorCode));


### PR DESCRIPTION
## 📌이슈 번호
- #9 

## 👩🏻‍💻구현 내용
- **마이페이지 조회 기능 구현**
  - 현재는 로그인 기능이 구현되어 있지 않아 SecurityContext에서 로그인한 사용자를 찾을 수 없음
    ➜ 임의의 `memberId`를 지정해두고 기능을 구현 
  - 추후에 SecurityContextHolder에서 로그인한 사용자의 memberId를 꺼내어 DB를 조회하는 것으로 변경할 예정

- **에러 코드 수정**
  - ErrorCode를 interface로 하고, 각각의 도메인에서 implement할 수 있도록 수정

- **회원가입 시, comment 고정**
  - 회원가입 할 때, comment를 입력하지 않아 마이페이지 조회 시, comment가 `null`로 출력 되고 있음.
  - comment를 `"안녕하세요"`를 기본으로 저장하도록 수정