### PR TITLE
feature: 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
+++ b/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.org.candoit.domain.member.controller;
 
+import com.org.candoit.domain.member.dto.CheckPasswordRequest;
 import com.org.candoit.domain.member.dto.MemberCheckRequest;
 import com.org.candoit.domain.member.dto.MemberJoinRequest;
 import com.org.candoit.domain.member.dto.MemberUpdateRequest;
@@ -8,6 +9,7 @@ import com.org.candoit.domain.member.service.MemberService;
 import com.org.candoit.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,5 +46,11 @@ public class MemberController {
     public ResponseEntity<ApiResponse<MyPageResponse>> updateMemberInfo(@RequestBody MemberUpdateRequest memberUpdateRequest){
         MyPageResponse myPageResponse = memberService.updateInfo(4l, memberUpdateRequest);
         return ResponseEntity.ok(ApiResponse.success(myPageResponse));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<ApiResponse<Object>> withdraw(@RequestBody CheckPasswordRequest checkPasswordRequest){
+        memberService.withdraw(6l, checkPasswordRequest);
+        return ResponseEntity.ok(ApiResponse.successWithoutData());
     }
 }

--- a/src/main/java/com/org/candoit/domain/member/dto/CheckPasswordRequest.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/CheckPasswordRequest.java
@@ -1,0 +1,9 @@
+package com.org.candoit.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CheckPasswordRequest {
+    private String type;
+    private String password;
+}

--- a/src/main/java/com/org/candoit/domain/member/entity/Member.java
+++ b/src/main/java/com/org/candoit/domain/member/entity/Member.java
@@ -2,6 +2,8 @@ package com.org.candoit.domain.member.entity;
 
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,11 +34,19 @@ public class Member extends BaseTimeEntity {
 
     private String profilePath;
 
+    @Enumerated(EnumType.STRING)
+    private MemberStatus memberStatus;
+
     public void updateInfo(String email, String nickname, String comment, String profilePath){
 
         this.email = email;
         this.nickname = nickname;
         this.comment = comment;
         this.profilePath = profilePath;
+    }
+
+    public void withdraw(){
+
+        this.memberStatus = MemberStatus.WITHDRAW;
     }
 }

--- a/src/main/java/com/org/candoit/domain/member/entity/MemberStatus.java
+++ b/src/main/java/com/org/candoit/domain/member/entity/MemberStatus.java
@@ -1,0 +1,6 @@
+package com.org.candoit.domain.member.entity;
+
+public enum MemberStatus {
+    WITHDRAW,
+    ACTIVITY;
+}

--- a/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements ErrorCode {
 
-    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "00000", "사용자를 찾지 못했습니다.");
+    NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "00000", "사용자를 찾지 못했습니다."),
+    NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "00001", "비밀번호가 일치하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -1,10 +1,12 @@
 package com.org.candoit.domain.member.service;
 
+import com.org.candoit.domain.member.dto.CheckPasswordRequest;
 import com.org.candoit.domain.member.dto.MemberCheckRequest;
 import com.org.candoit.domain.member.dto.MemberJoinRequest;
 import com.org.candoit.domain.member.dto.MemberUpdateRequest;
 import com.org.candoit.domain.member.dto.MyPageResponse;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberStatus;
 import com.org.candoit.domain.member.exception.MemberErrorCode;
 import com.org.candoit.domain.member.repository.MemberRepository;
 import com.org.candoit.global.response.CustomException;
@@ -27,6 +29,7 @@ public class MemberService {
             .comment("안녕하세요.")
             .password(memberJoinRequest.getPassword())
             .nickname(memberJoinRequest.getNickname())
+            .memberStatus(MemberStatus.ACTIVITY)
             .build();
 
         memberRepository.save(saveRequestMember);
@@ -73,5 +76,17 @@ public class MemberService {
             .email(memberUpdateRequest.getEmail())
             .nickname(memberUpdateRequest.getNickname())
             .build();
+    }
+
+    public void withdraw(Long memberId, CheckPasswordRequest checkPasswordRequest){
+
+        Member memberToWithdraw = memberRepository.findById(memberId).orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
+        if(!checkPasswordRequest.getType().equals("WITHDRAW")){
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+        if(!checkPasswordRequest.getPassword().equals(memberToWithdraw.getPassword())){
+            throw new CustomException(MemberErrorCode.NOT_MATCHED_PASSWORD);
+        }
+        memberToWithdraw.withdraw();
     }
 }


### PR DESCRIPTION
## 📌이슈 번호
- #12 

## 👩🏻‍💻구현 내용
- **회원 탈퇴 기능 구현**
  - Member 엔티티에 `memberStatus`를 추가
  - 현재는 문자열 비교를 통해 비밀번호 일치를 판단
   ➜ Spring Security 도입 후, Bcrypt의 matches 메서드를 사용하여 비밀번호 일치 여부를 판단할 예정