### PR TITLE
 feature: 로그인 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 
     // Web
@@ -42,6 +44,16 @@ dependencies {
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.springframework.security:spring-security-test'
+
+    // Security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,22 @@ repositories {
 }
 
 dependencies {
+    // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
-    compileOnly 'org.projectlombok:lombok'
-    developmentOnly 'org.springframework.boot:spring-boot-devtools'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+    // Web
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package com.org.candoit.domain.auth.controller;
+
+import com.org.candoit.domain.auth.dto.LoginRequest;
+import com.org.candoit.domain.auth.dto.LoginResponse;
+import com.org.candoit.domain.auth.service.AuthService;
+import com.org.candoit.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<Object>> login(@RequestBody LoginRequest loginRequest) {
+        LoginResponse loginResponse = authService.login(loginRequest);
+
+        return ResponseEntity.ok()
+            .headers(loginResponse.getHttpHeaders())
+            .body(ApiResponse.successWithoutData());
+
+    }
+}

--- a/src/main/java/com/org/candoit/domain/auth/dto/LoginRequest.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LoginRequest {
+
+    private String id;
+    private String password;
+}

--- a/src/main/java/com/org/candoit/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,15 @@
+package com.org.candoit.domain.auth.dto;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpHeaders;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+
+    private HttpHeaders httpHeaders;
+}

--- a/src/main/java/com/org/candoit/domain/auth/dto/NewTokenResponse.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/NewTokenResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NewTokenResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/org/candoit/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AuthErrorCode implements ErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"14000", "다시 로그인 해주세요.");
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"14000", "로그인된 사용자가 아닙니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/org/candoit/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,18 @@
+package com.org.candoit.domain.auth.exception;
+
+import com.org.candoit.global.response.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum AuthErrorCode implements ErrorCode {
+
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"14000", "다시 로그인 해주세요.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
@@ -1,0 +1,58 @@
+package com.org.candoit.domain.auth.service;
+
+import com.org.candoit.domain.auth.dto.LoginRequest;
+import com.org.candoit.domain.auth.dto.LoginResponse;
+import com.org.candoit.global.security.jwt.JwtUtil;
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final JwtUtil jwtUtil;
+
+    public LoginResponse login(LoginRequest loginRequest) {
+
+        Authentication authentication = null;
+        try {
+            authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(loginRequest.getId(),
+                    loginRequest.getPassword()));
+        } catch (AuthenticationException e) {
+            throw new RuntimeException(e);
+        }
+
+        String accessToken = jwtUtil.generateAccessToken(authentication);
+        String refreshToken = jwtUtil.generateRefreshToken(authentication);
+
+        HttpHeaders headers = new HttpHeaders();
+        accessTokenSend2Client(headers, accessToken);
+        refreshTokenSend2Client(headers, refreshToken, 7);
+
+        return new LoginResponse(headers);
+    }
+    private void accessTokenSend2Client(HttpHeaders headers, String accessToken) {
+        headers.set("Authorization", "Bearer " + accessToken);
+    }
+
+    private void refreshTokenSend2Client(HttpHeaders headers, String refreshToken, long duration) {
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refresh-token", refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .path("/")
+            .maxAge(Duration.ofDays(duration))
+            .sameSite("None")
+            .build();
+
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+    }
+}

--- a/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.org.candoit.domain.auth.dto.LoginResponse;
 import com.org.candoit.global.security.jwt.JwtUtil;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -13,6 +14,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class AuthService {
@@ -22,7 +24,7 @@ public class AuthService {
 
     public LoginResponse login(LoginRequest loginRequest) {
 
-        Authentication authentication = null;
+        Authentication authentication;
         try {
             authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(loginRequest.getId(),

--- a/src/main/java/com/org/candoit/domain/member/entity/Member.java
+++ b/src/main/java/com/org/candoit/domain/member/entity/Member.java
@@ -37,6 +37,9 @@ public class Member extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private MemberStatus memberStatus;
 
+    @Enumerated(EnumType.STRING)
+    private MemberRole memberRole;
+
     public void updateInfo(String email, String nickname, String comment, String profilePath){
 
         this.email = email;

--- a/src/main/java/com/org/candoit/domain/member/entity/MemberRole.java
+++ b/src/main/java/com/org/candoit/domain/member/entity/MemberRole.java
@@ -1,0 +1,6 @@
+package com.org.candoit.domain.member.entity;
+
+public enum MemberRole {
+    ROLE_ADMIN,
+    ROLE_USER;
+}

--- a/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode implements ErrorCode {
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "00000", "사용자를 찾지 못했습니다."),
-    NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "00001", "비밀번호가 일치하지 않습니다.");
+    NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "00001", "비밀번호가 일치하지 않습니다."),
+    WITHDRAWN_MEMBER(HttpStatus.BAD_REQUEST, "00002", "탈퇴한 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -6,6 +6,7 @@ import com.org.candoit.domain.member.dto.MemberJoinRequest;
 import com.org.candoit.domain.member.dto.MemberUpdateRequest;
 import com.org.candoit.domain.member.dto.MyPageResponse;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberRole;
 import com.org.candoit.domain.member.entity.MemberStatus;
 import com.org.candoit.domain.member.exception.MemberErrorCode;
 import com.org.candoit.domain.member.repository.MemberRepository;
@@ -30,6 +31,7 @@ public class MemberService {
             .password(memberJoinRequest.getPassword())
             .nickname(memberJoinRequest.getNickname())
             .memberStatus(MemberStatus.ACTIVITY)
+            .memberRole(MemberRole.ROLE_USER)
             .build();
 
         memberRepository.save(saveRequestMember);

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -13,6 +13,7 @@ import com.org.candoit.domain.member.repository.MemberRepository;
 import com.org.candoit.global.response.CustomException;
 import com.org.candoit.global.response.GlobalErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,13 +23,14 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public void join(MemberJoinRequest memberJoinRequest){
 
         Member saveRequestMember = Member.builder()
             .email(memberJoinRequest.getEmail())
             .comment("안녕하세요.")
-            .password(memberJoinRequest.getPassword())
+            .password(bCryptPasswordEncoder.encode(memberJoinRequest.getPassword()))
             .nickname(memberJoinRequest.getNickname())
             .memberStatus(MemberStatus.ACTIVITY)
             .memberRole(MemberRole.ROLE_USER)

--- a/src/main/java/com/org/candoit/global/annotation/LoginMember.java
+++ b/src/main/java/com/org/candoit/global/annotation/LoginMember.java
@@ -1,0 +1,12 @@
+package com.org.candoit.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+
+}

--- a/src/main/java/com/org/candoit/global/annotation/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/org/candoit/global/annotation/LoginMemberArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.org.candoit.global.annotation;
+
+import com.org.candoit.domain.auth.exception.AuthErrorCode;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.security.basic.CustomUserDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class)
+            && parameter.getParameterType().equals(Member.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if(authentication == null || !authentication.isAuthenticated()||
+        authentication.getPrincipal().equals("anonymousUser")) {
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        return userDetails.getMember();
+    }
+}

--- a/src/main/java/com/org/candoit/global/config/RedisConfig.java
+++ b/src/main/java/com/org/candoit/global/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package com.org.candoit.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory(){
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(){
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -1,0 +1,90 @@
+package com.org.candoit.global.config;
+
+import com.org.candoit.domain.member.entity.MemberRole;
+import com.org.candoit.global.security.CustomAuthenticationProvider;
+import com.org.candoit.global.security.basic.CustomUserDetailsService;
+import com.org.candoit.global.security.exception.CustomAuthenticationEntryPoint;
+import com.org.candoit.global.security.filter.JwtAuthorizationFilter;
+import com.org.candoit.global.security.jwt.JwtUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CustomAuthenticationProvider customAuthenticationProvider() {
+        return new CustomAuthenticationProvider(customUserDetailsService, bCryptPasswordEncoder());
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter(JwtUtil jwtUtil) {
+        return new JwtAuthorizationFilter(jwtUtil);
+    }
+
+    @Bean
+    AuthenticationManager authenticationManager() {
+        return new ProviderManager(List.of(customAuthenticationProvider()));
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+            .authorizeHttpRequests(auth -> auth
+                // 문서화 api
+                .requestMatchers("/",
+                    "/swagger-ui/**",
+                    "/v3/api-docs/**").permitAll()
+                // 로그인, 회원가입
+                .requestMatchers("/api/auth/login", "/api/members/join"
+                    ).permitAll()
+                .requestMatchers("/api/members/check").hasRole("USER")
+                .anyRequest().authenticated()
+            );
+
+        // 기본 로그인 관련 설정
+        http
+            .formLogin(auth -> auth.disable())
+            .httpBasic(auth -> auth.disable())
+            .sessionManagement(
+                session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        // csrf 비활성화
+        http.csrf(AbstractHttpConfigurer::disable);
+
+        http
+            .addFilterAfter(jwtAuthorizationFilter(jwtUtil),
+                UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling(
+            exception -> exception.authenticationEntryPoint(customAuthenticationEntryPoint));
+
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/org/candoit/global/config/SwaggerConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package com.org.candoit.global.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,9 +13,17 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+        SecurityScheme apiKey = new SecurityScheme()
+            .type(SecurityScheme.Type.APIKEY)
+            .in(SecurityScheme.In.HEADER)
+            .name("Authorization");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+            .addList("Bearer Token");
+
         return new OpenAPI()
-            .components(new Components())
-            .info(apiInfo());
+            .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+            .addSecurityItem(securityRequirement);
     }
 
     private Info apiInfo() {

--- a/src/main/java/com/org/candoit/global/config/WebConfig.java
+++ b/src/main/java/com/org/candoit/global/config/WebConfig.java
@@ -1,0 +1,22 @@
+package com.org.candoit.global.config;
+
+import com.org.candoit.global.annotation.LoginMemberArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/org/candoit/global/security/CustomAuthenticationProvider.java
@@ -1,0 +1,52 @@
+package com.org.candoit.global.security;
+
+import com.org.candoit.domain.member.exception.MemberErrorCode;
+import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.security.basic.CustomUserDetails;
+import com.org.candoit.global.security.basic.CustomUserDetailsService;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.DisabledException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@RequiredArgsConstructor
+public class CustomAuthenticationProvider implements AuthenticationProvider {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication)
+        throws AuthenticationException {
+
+        String username = authentication.getName();
+        String password = (String) authentication.getCredentials();
+
+        CustomUserDetails customUserDetails = null;
+
+        try {
+            customUserDetails = customUserDetailsService.loadUserByUsername(username);
+        } catch (UsernameNotFoundException e) {
+            throw new CustomException(MemberErrorCode.NOT_FOUND_MEMBER);
+        } catch (DisabledException e) {
+            throw new CustomException(MemberErrorCode.WITHDRAWN_MEMBER);
+        }
+
+        if(password != null && !bCryptPasswordEncoder.matches(password, customUserDetails.getPassword())) {
+            throw new CustomException(MemberErrorCode.NOT_FOUND_MEMBER);
+        }
+
+        return new UsernamePasswordAuthenticationToken(customUserDetails, null,
+            customUserDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/basic/CustomUserDetails.java
+++ b/src/main/java/com/org/candoit/global/security/basic/CustomUserDetails.java
@@ -1,0 +1,36 @@
+package com.org.candoit.global.security.basic;
+
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberStatus;
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@AllArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return member.getMemberStatus() == MemberStatus.ACTIVITY;
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
+++ b/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
@@ -1,0 +1,26 @@
+package com.org.candoit.global.security.basic;
+
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.exception.MemberErrorCode;
+import com.org.candoit.domain.member.repository.MemberRepository;
+import com.org.candoit.global.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        Member findMember = memberRepository.findByEmail(username).orElseThrow(()->new CustomException(
+            MemberErrorCode.NOT_FOUND_MEMBER));
+
+        return new CustomUserDetails(findMember);
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
+++ b/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
@@ -18,10 +18,12 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public CustomUserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    public CustomUserDetails loadUserByUsername(String userInfo) throws UsernameNotFoundException {
 
-        Member findMember = memberRepository.findByEmail(username).orElseThrow(()->new CustomException(
-            MemberErrorCode.NOT_FOUND_MEMBER));
+        Member findMember = (userInfo.contains("@"))?memberRepository.findByEmail(userInfo)
+            .orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER)):
+        memberRepository.findById(Long.parseLong(userInfo))
+            .orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
 
         if(findMember.getMemberStatus() == MemberStatus.WITHDRAW){
             throw new DisabledException(MemberErrorCode.WITHDRAWN_MEMBER.getMessage());

--- a/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
+++ b/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
@@ -1,10 +1,12 @@
 package com.org.candoit.global.security.basic;
 
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberStatus;
 import com.org.candoit.domain.member.exception.MemberErrorCode;
 import com.org.candoit.domain.member.repository.MemberRepository;
 import com.org.candoit.global.response.CustomException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -20,6 +22,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
         Member findMember = memberRepository.findByEmail(username).orElseThrow(()->new CustomException(
             MemberErrorCode.NOT_FOUND_MEMBER));
+
+        if(findMember.getMemberStatus() == MemberStatus.WITHDRAW){
+            throw new DisabledException(MemberErrorCode.WITHDRAWN_MEMBER.getMessage());
+        }
 
         return new CustomUserDetails(findMember);
     }

--- a/src/main/java/com/org/candoit/global/security/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/org/candoit/global/security/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,46 @@
+package com.org.candoit.global.security.exception;
+
+import com.org.candoit.global.security.jwt.TokenErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+        AuthenticationException authException) throws IOException, ServletException {
+
+        String exceptionMessage = (String) request.getAttribute("exception");
+        String errorCode = "";
+        String errorMessage = "";
+
+        if("EXPIRED_ACCESS_TOKEN".equals(exceptionMessage)){
+            errorCode = TokenErrorCode.EXPIRED_ACCESS_TOKEN.getCode();
+            errorMessage = TokenErrorCode.EXPIRED_ACCESS_TOKEN.getMessage();
+        }else if("EXPIRED_REFRESH_TOKEN".equals(exceptionMessage)){
+            errorCode = TokenErrorCode.EXPIRED_REFRESH_TOKEN.getCode();
+            errorMessage = TokenErrorCode.EXPIRED_REFRESH_TOKEN.getMessage();
+        }else if("INVALID_TOKEN".equals(exceptionMessage)){
+            errorCode = TokenErrorCode.INVALID_TOKEN.getCode();
+            errorMessage = TokenErrorCode.INVALID_TOKEN.getMessage();
+        }else if("ACCESS_TOKEN_NOT_EXIST".equals(exceptionMessage)){
+            errorCode = TokenErrorCode.ACCESS_TOKEN_NOT_EXIST.getCode();
+            errorMessage = TokenErrorCode.ACCESS_TOKEN_NOT_EXIST.getMessage();
+        }else if("REFRESH_TOKEN_EXPIRED".equals(exceptionMessage)){
+            errorCode = TokenErrorCode.REFRESH_TOKEN_NOT_EXIST.getCode();
+            errorMessage = TokenErrorCode.REFRESH_TOKEN_NOT_EXIST.getMessage();
+        }
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().write("{\"code\": "+errorCode+",\"message\": \""+errorMessage+"\"}");
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,82 @@
+package com.org.candoit.global.security.filter;
+
+import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.security.jwt.JwtUtil;
+import com.org.candoit.global.security.jwt.TokenErrorCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Set;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+
+    private static final String EXCEPTION_ATTRIBUTE = "exception";
+    private final JwtUtil jwtUtil;
+    private AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+    private final Set<String> excludeAllPaths = Set.of(
+        "/swagger-ui/**", "/v3/api-docs/**",
+        "/api/auth/login", "/api/members/join"
+    );
+
+    public JwtAuthorizationFilter(JwtUtil jwtUtil) {
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+        FilterChain filterChain) throws ServletException, IOException {
+
+        if (isExcludedPath(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = null;
+
+        try {
+            accessToken = jwtUtil.removePrefixFromAccessToken(request.getHeader("Authorization"));
+            jwtUtil.parseToken(accessToken);
+        } catch (CustomException e) {
+            if (e.getErrorCode() == TokenErrorCode.ACCESS_TOKEN_NOT_EXIST) {
+                request.setAttribute(EXCEPTION_ATTRIBUTE, "ACCESS_TOKEN_NOT_EXIST");
+            }
+        } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
+
+            request.setAttribute(EXCEPTION_ATTRIBUTE, "INVALID_TOKEN");
+            throw new CustomException(TokenErrorCode.INVALID_TOKEN);
+        } catch (ExpiredJwtException e) {
+
+            request.setAttribute(EXCEPTION_ATTRIBUTE, "EXPIRED_ACCESS_TOKEN");
+            throw new CustomException(TokenErrorCode.EXPIRED_ACCESS_TOKEN);
+        }
+
+        if (jwtUtil.checkBlacklist(accessToken)) {
+            request.setAttribute(EXCEPTION_ATTRIBUTE, "INVALID_TOKEN");
+            throw new CustomException(TokenErrorCode.INVALID_TOKEN);
+        }
+
+        Authentication authentication = jwtUtil.getAuthentication(accessToken);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean isExcludedPath(HttpServletRequest request) {
+        String path = request.getRequestURI();
+
+        boolean isExcluded = excludeAllPaths.stream()
+            .anyMatch(pattern -> antPathMatcher.match(pattern, path));
+
+        return isExcluded;
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -51,7 +51,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
                 request.setAttribute(EXCEPTION_ATTRIBUTE, "ACCESS_TOKEN_NOT_EXIST");
             }
         } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
-
             request.setAttribute(EXCEPTION_ATTRIBUTE, "INVALID_TOKEN");
             throw new CustomException(TokenErrorCode.INVALID_TOKEN);
         } catch (ExpiredJwtException e) {
@@ -74,9 +73,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private boolean isExcludedPath(HttpServletRequest request) {
         String path = request.getRequestURI();
 
-        boolean isExcluded = excludeAllPaths.stream()
+        return excludeAllPaths.stream()
             .anyMatch(pattern -> antPathMatcher.match(pattern, path));
-
-        return isExcluded;
     }
 }

--- a/src/main/java/com/org/candoit/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/JwtUtil.java
@@ -1,0 +1,123 @@
+package com.org.candoit.global.security.jwt;
+
+import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.security.basic.CustomUserDetails;
+import com.org.candoit.global.security.basic.CustomUserDetailsService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final Key key;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private Long accessTokenExpiration;
+    private Long refreshTokenExpiration;
+
+    public JwtUtil(@Value("${jwt.secret}") String secretKey,
+        @Value("${jwt.access-token-expiration}") Long accessTokenExpiration,
+        @Value("${jwt.refresh-token-expiration}") Long refreshTokenExpiration,
+        RefreshTokenRepository refreshTokenRepository,
+        CustomUserDetailsService customUserDetailsService,
+        RedisTemplate<String, String> redisTemplate) {
+        this.refreshTokenRepository = refreshTokenRepository;
+        this.customUserDetailsService = customUserDetailsService;
+        this.redisTemplate = redisTemplate;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    public String generateAccessToken(Authentication authentication) {
+        CustomUserDetails nowMember = (CustomUserDetails) authentication.getPrincipal();
+
+        Instant nowTime = Instant.now();
+
+        return Jwts.builder()
+            .subject(nowMember.getMember().getMemberId().toString())
+            .claim("status", nowMember.getMember().getMemberStatus().name())
+            .claim("auth", nowMember.getMember().getMemberRole().name())
+            .issuedAt(Date.from(nowTime))
+            .expiration(Date.from(nowTime.plus(accessTokenExpiration, ChronoUnit.MILLIS)))
+            .compact();
+    }
+
+    public String generateRefreshToken(Authentication authentication) {
+        CustomUserDetails nowMember = (CustomUserDetails) authentication.getPrincipal();
+
+        Instant nowTime = Instant.now();
+
+        return Jwts.builder()
+            .subject(nowMember.getMember().getMemberId().toString())
+            .issuedAt(Date.from(nowTime))
+            .expiration(Date.from(nowTime.plus(refreshTokenExpiration, ChronoUnit.MILLIS)))
+            .compact();
+    }
+
+    public Claims parseToken(String token) {
+        return Jwts.parser()
+            .verifyWith((SecretKey) key)
+            .build()
+            .parseSignedClaims(token)
+            .getPayload();
+    }
+
+    public String removePrefixFromAccessToken(String bearerToken) {
+        if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+            throw new CustomException(TokenErrorCode.ACCESS_TOKEN_NOT_EXIST);
+        }
+        return bearerToken.substring(7);
+    }
+
+    public boolean checkBlacklist(String accessToken) {
+        Boolean isInBlackList = redisTemplate.hasKey("blacklist:access-token:" + accessToken);
+        Boolean isInPendingBlackList = redisTemplate.hasKey(("pending-blacklist:access-token:" + accessToken));
+
+        return Boolean.TRUE.equals(isInBlackList)&& Boolean.FALSE.equals(isInPendingBlackList);
+    }
+
+    public void addBlackListExistingAccessToken(String accessToken, Date expirationDate) {
+
+        redisTemplate.opsForValue()
+            .set("pending-blacklist:access-token:"+accessToken, "pending",5, TimeUnit.MINUTES);
+
+        redisTemplate.opsForValue()
+            .set("blacklist:access-token:" + accessToken, expirationDate.toString(),
+                Duration.between(new Date().toInstant(), expirationDate.toInstant()).getSeconds(),
+                TimeUnit.SECONDS);
+    }
+
+    public void validateAccessTokenExpiration(Claims accessTokenClaims, String accessToken) {
+        Date accessTokenExpirationDate = accessTokenClaims.getExpiration();
+
+        if(accessTokenExpirationDate.after(new Date())) {
+            addBlackListExistingAccessToken(accessToken, accessTokenExpirationDate);
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+
+        String memberId = parseToken(token).getSubject();
+
+        CustomUserDetails customUserDetails = customUserDetailsService.loadUserByUsername(String.valueOf(memberId));
+        return new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/jwt/RefreshToken.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/RefreshToken.java
@@ -1,0 +1,16 @@
+package com.org.candoit.global.security.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class RefreshToken {
+
+    private String memberId;
+    private String refreshTokenValue;
+}

--- a/src/main/java/com/org/candoit/global/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/RefreshTokenRepository.java
@@ -1,0 +1,28 @@
+package com.org.candoit.global.security.jwt;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PREFIX = "refresh_token:member:";
+
+    public void save(Long memberId, String refreshToken) {
+        redisTemplate.opsForValue()
+            .set(PREFIX + String.valueOf(memberId), refreshToken, 7, TimeUnit.DAYS);
+    }
+
+    public String findByMemberId(String memberId) {
+        return redisTemplate.opsForValue().get(PREFIX + memberId);
+    }
+
+    public void delete(String memberId) {
+        redisTemplate.delete(PREFIX + memberId);
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/jwt/TokenErrorCode.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/TokenErrorCode.java
@@ -1,0 +1,21 @@
+package com.org.candoit.global.security.jwt;
+
+import com.org.candoit.global.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+@Getter
+public enum TokenErrorCode implements ErrorCode {
+
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "01000", "유효하지 않은 토큰 입니다"),
+    EXPIRED_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "01001", "만료된 액세스 토큰입니다."),
+    EXPIRED_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "01002", "만료된 리프레시 토큰입니다."),
+    ACCESS_TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED,"01003","액세스 토큰이 존재하지 않습니다."),
+    REFRESH_TOKEN_NOT_EXIST(HttpStatus.UNAUTHORIZED,"01004","리프레시 토큰이 존재하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}


### PR DESCRIPTION
## 📌이슈 번호
- #5  

## 👩🏻‍💻구현 내용
- **로그인 기능 구현**
이전 프로젝트에서 구현한 내용을 사용하여 로그인 기능을 구현했습니다.
현재는 프론트와 연동하지 않은 상태이기 때문에 cors 설정은 하지 않았으나, 이후 배포와 api 연동을 할 경우 cors 설정을 추가할 예정입니다.


- **로그인한 사용자를 가져오는 `@ LoginMember` 어노테이션 구현**
로그인한 사용자를 SecurityContextHolder에서 가져오기 위해,  커스텀 어노테이션 `@ LoginMember`를 만들고, `ArgumentResolver`로 처리했습니다.  

  이전에 사용했던 Spring Expression Language 방식과 비교하면 다음과 같습니다.

     1. **표현식**을 사용하는 방법
      - 장점: 빠르고, 간단하게 만들 수 있음. 
      - 단점: 세부적인 관리 불가
    2. **ArgumentResolver**를 사용하는 방법
      - 장점: 세부적으로 관리 가능
      - 단점: 표현식보다는 좀 더 복잡하고, 작성하는 데 시간이 상대적으로 오래 걸림.

✅  메서드를 사용하여 어노테이션 작동을 관리할 수 있기 때문에 세부적으로 인증 객체를 다루고자 한다면 `ArgumentResolver`를 사용하는 것이 좋다고 생각했습니다.