### PR TITLE
feature: 마이페이지 비밀번호 변경기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
+++ b/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
@@ -5,8 +5,12 @@ import com.org.candoit.domain.member.dto.MemberCheckRequest;
 import com.org.candoit.domain.member.dto.MemberJoinRequest;
 import com.org.candoit.domain.member.dto.MemberUpdateRequest;
 import com.org.candoit.domain.member.dto.MyPageResponse;
+import com.org.candoit.domain.member.dto.NewPasswordRequest;
+import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.member.service.MemberService;
+import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -51,6 +55,18 @@ public class MemberController {
     @DeleteMapping
     public ResponseEntity<ApiResponse<Object>> withdraw(@RequestBody CheckPasswordRequest checkPasswordRequest){
         memberService.withdraw(6l, checkPasswordRequest);
+        return ResponseEntity.ok(ApiResponse.successWithoutData());
+    }
+
+    @PostMapping("password-check")
+    public ResponseEntity<ApiResponse<Object>> checkCorrectPassword(@Parameter(hidden = true) @LoginMember Member loginMember,@RequestBody CheckPasswordRequest checkPasswordRequest){
+        memberService.checkPassword(loginMember, checkPasswordRequest);
+        return ResponseEntity.ok(ApiResponse.successWithoutData());
+    }
+
+    @PatchMapping("/change-password")
+    public ResponseEntity<ApiResponse<Object>> updatePassword(@Parameter(hidden = true) @LoginMember Member loginMember, @RequestBody NewPasswordRequest newPasswordRequest){
+        memberService.updatePassword(loginMember.getMemberId(), newPasswordRequest);
         return ResponseEntity.ok(ApiResponse.successWithoutData());
     }
 }

--- a/src/main/java/com/org/candoit/domain/member/dto/NewPasswordRequest.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/NewPasswordRequest.java
@@ -1,0 +1,8 @@
+package com.org.candoit.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NewPasswordRequest {
+    private String newPassword;
+}

--- a/src/main/java/com/org/candoit/domain/member/entity/Member.java
+++ b/src/main/java/com/org/candoit/domain/member/entity/Member.java
@@ -48,6 +48,10 @@ public class Member extends BaseTimeEntity {
         this.profilePath = profilePath;
     }
 
+    public void updatePassword(String password){
+        this.password = password;
+    }
+
     public void withdraw(){
 
         this.memberStatus = MemberStatus.WITHDRAW;

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.org.candoit.global.config;
 
-import com.org.candoit.domain.member.entity.MemberRole;
 import com.org.candoit.global.security.CustomAuthenticationProvider;
 import com.org.candoit.global.security.basic.CustomUserDetailsService;
 import com.org.candoit.global.security.exception.CustomAuthenticationEntryPoint;

--- a/src/main/java/com/org/candoit/global/security/basic/CustomUserDetails.java
+++ b/src/main/java/com/org/candoit/global/security/basic/CustomUserDetails.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
 @Getter
@@ -16,7 +17,7 @@ public class CustomUserDetails implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of();
+        return List.of(new SimpleGrantedAuthority(member.getMemberRole().name()));
     }
 
     @Override


### PR DESCRIPTION
## 📌이슈 번호
- #13 

## 👩🏻‍💻구현 내용
### 현재 비밀번호 확인
- 사용자가 입력한 현재 비밀번호가 일치하는 경우, `redis`에 `check-password:new-password:_{memberId}_ : checked`로 저장
➜ 실제 비밀번호 변경 요청 시, 사용자가 인증을 마쳤는지 검증

### 비밀번호 변경
- `checkVerify()` 메서드를 사용해서 비밀번호 확인 절차를 거쳤는지 확인
- `redis`에 해당 키가 있는 경우, 데이터를 삭제. 이후, 더티체킹으로 비밀번호를 변경