### PR TITLE
feature: 로그아웃 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
@@ -2,12 +2,16 @@ package com.org.candoit.domain.auth.controller;
 
 import com.org.candoit.domain.auth.dto.LoginRequest;
 import com.org.candoit.domain.auth.dto.LoginResponse;
+import com.org.candoit.domain.auth.dto.LogoutResponse;
 import com.org.candoit.domain.auth.service.AuthService;
 import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +30,15 @@ public class AuthController {
             .headers(loginResponse.getHttpHeaders())
             .body(ApiResponse.successWithoutData());
 
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Object>> logout(
+        @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
+        @Parameter(hidden = true) @CookieValue(name = "refresh-token") String refreshToken
+    ) {
+        LogoutResponse logoutResponse = authService.logout(accessToken, refreshToken);
+        return ResponseEntity.ok().headers(logoutResponse.getHttpHeaders())
+            .body(ApiResponse.successWithoutData());
     }
 }

--- a/src/main/java/com/org/candoit/domain/auth/dto/LogoutResponse.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/LogoutResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpHeaders;
+
+@Getter
+@AllArgsConstructor
+public class LogoutResponse {
+
+    private HttpHeaders httpHeaders;
+}

--- a/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
@@ -2,6 +2,8 @@ package com.org.candoit.domain.auth.service;
 
 import com.org.candoit.domain.auth.dto.LoginRequest;
 import com.org.candoit.domain.auth.dto.LoginResponse;
+import com.org.candoit.domain.auth.dto.LogoutResponse;
+import com.org.candoit.global.security.jwt.JwtService;
 import com.org.candoit.global.security.jwt.JwtUtil;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class AuthService {
 
     private final AuthenticationManager authenticationManager;
     private final JwtUtil jwtUtil;
+    private final JwtService jwtService;
 
     public LoginResponse login(LoginRequest loginRequest) {
 
@@ -56,5 +59,14 @@ public class AuthService {
             .build();
 
         headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+    }
+
+    public LogoutResponse logout(String accessToken, String refreshToken) {
+        jwtService.logout(accessToken);
+
+        HttpHeaders headers = new HttpHeaders();
+        refreshTokenSend2Client(headers, refreshToken, 0);
+
+        return new LogoutResponse(headers);
     }
 }

--- a/src/main/java/com/org/candoit/domain/member/entity/Member.java
+++ b/src/main/java/com/org/candoit/domain/member/entity/Member.java
@@ -53,7 +53,6 @@ public class Member extends BaseTimeEntity {
     }
 
     public void withdraw(){
-
         this.memberStatus = MemberStatus.WITHDRAW;
     }
 }

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                 // 로그인, 회원가입
                 .requestMatchers("/api/auth/login", "/api/members/join"
                     ).permitAll()
-                .requestMatchers("/api/members/check").hasRole("USER")
+                .requestMatchers("/api/members/check", "/api/auth/logout").hasRole("USER")
                 .anyRequest().authenticated()
             );
 

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -49,6 +49,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         } catch (CustomException e) {
             if (e.getErrorCode() == TokenErrorCode.ACCESS_TOKEN_NOT_EXIST) {
                 request.setAttribute(EXCEPTION_ATTRIBUTE, "ACCESS_TOKEN_NOT_EXIST");
+                throw new CustomException(TokenErrorCode.ACCESS_TOKEN_NOT_EXIST);
             }
         } catch (MalformedJwtException | UnsupportedJwtException | IllegalArgumentException e) {
             request.setAttribute(EXCEPTION_ATTRIBUTE, "INVALID_TOKEN");
@@ -60,8 +61,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         }
 
         if (jwtUtil.checkBlacklist(accessToken)) {
-            request.setAttribute(EXCEPTION_ATTRIBUTE, "INVALID_TOKEN");
-            throw new CustomException(TokenErrorCode.INVALID_TOKEN);
+            request.setAttribute(EXCEPTION_ATTRIBUTE, "ACCESS_TOKEN_NOT_EXIST");
+            throw new CustomException(TokenErrorCode.ACCESS_TOKEN_NOT_EXIST);
         }
 
         Authentication authentication = jwtUtil.getAuthentication(accessToken);

--- a/src/main/java/com/org/candoit/global/security/jwt/JwtService.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/JwtService.java
@@ -1,0 +1,30 @@
+package com.org.candoit.global.security.jwt;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class JwtService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtUtil jwtUtil;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void logout(String accessToken) {
+
+        String extractAccessToken = jwtUtil.removePrefixFromAccessToken(accessToken);
+        Claims claimsAccessToken = jwtUtil.extractClaimsOrThrow("accessToken", extractAccessToken);
+
+        jwtUtil.addBlackListExistingAccessToken(extractAccessToken,
+            claimsAccessToken.getExpiration());
+
+        if (!refreshTokenRepository.findByMemberId(claimsAccessToken.getSubject()).isEmpty()) {
+            refreshTokenRepository.delete(claimsAccessToken.getSubject());
+        }
+    }
+}

--- a/src/main/java/com/org/candoit/global/security/jwt/RefreshTokenRepository.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/RefreshTokenRepository.java
@@ -14,8 +14,9 @@ public class RefreshTokenRepository {
     private static final String PREFIX = "refresh_token:member:";
 
     public void save(Long memberId, String refreshToken) {
+
         redisTemplate.opsForValue()
-            .set(PREFIX + String.valueOf(memberId), refreshToken, 7, TimeUnit.DAYS);
+            .set(PREFIX + memberId, refreshToken, 7, TimeUnit.DAYS);
     }
 
     public String findByMemberId(String memberId) {


### PR DESCRIPTION
## 📌이슈 번호
- #17 

## 👩🏻‍💻구현 내용
- 로그아웃 기능 구현
   - 액세스 토큰
    로그아웃 기능을 구현했습니다. 로그아웃 요청이 오면, 액세스 토큰이 유효한 시간 만큼 레디스에 저장하여, 해당 액세스 토큰으로 필터를 통과하지 못하도록 처리했습니다. (블랙리스트 처리)

   - 리프레시 토큰
   리프레시 토큰을 삭제하여 레디스에 불필요한 정보가 남아있지 않도록 구현했습니다.