### PR TITLE
feature: 토큰 재발행 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.org.candoit.domain.auth.controller;
 import com.org.candoit.domain.auth.dto.LoginRequest;
 import com.org.candoit.domain.auth.dto.LoginResponse;
 import com.org.candoit.domain.auth.dto.LogoutResponse;
+import com.org.candoit.domain.auth.dto.ReissueResponse;
 import com.org.candoit.domain.auth.service.AuthService;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -39,6 +40,15 @@ public class AuthController {
     ) {
         LogoutResponse logoutResponse = authService.logout(accessToken, refreshToken);
         return ResponseEntity.ok().headers(logoutResponse.getHttpHeaders())
+            .body(ApiResponse.successWithoutData());
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<ApiResponse<Object>> reissue(
+        @RequestHeader("Authorization") String accessToken,
+        @Parameter(hidden = true) @CookieValue(name = "refresh-token") String refreshToken) {
+        ReissueResponse reissueResponse = authService.reissue(accessToken, refreshToken);
+        return ResponseEntity.ok().headers(reissueResponse.getHttpHeaders())
             .body(ApiResponse.successWithoutData());
     }
 }

--- a/src/main/java/com/org/candoit/domain/auth/dto/ReissueResponse.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/ReissueResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpHeaders;
+
+@Getter
+@AllArgsConstructor
+public class ReissueResponse {
+
+    private HttpHeaders httpHeaders;
+}

--- a/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.org.candoit.domain.auth.service;
 import com.org.candoit.domain.auth.dto.LoginRequest;
 import com.org.candoit.domain.auth.dto.LoginResponse;
 import com.org.candoit.domain.auth.dto.LogoutResponse;
+import com.org.candoit.domain.auth.dto.NewTokenResponse;
+import com.org.candoit.domain.auth.dto.ReissueResponse;
 import com.org.candoit.global.security.jwt.JwtService;
 import com.org.candoit.global.security.jwt.JwtUtil;
 import java.time.Duration;
@@ -68,5 +70,15 @@ public class AuthService {
         refreshTokenSend2Client(headers, refreshToken, 0);
 
         return new LogoutResponse(headers);
+    }
+
+    public ReissueResponse reissue(String refreshToken, String accessToken) {
+
+        NewTokenResponse newTokenResponse = jwtService.reissue(refreshToken, accessToken);
+        HttpHeaders headers = new HttpHeaders();
+        accessTokenSend2Client(headers, newTokenResponse.getAccessToken());
+        refreshTokenSend2Client(headers, newTokenResponse.getRefreshToken(), 7);
+
+        return new ReissueResponse(headers);
     }
 }

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -59,8 +59,8 @@ public class SecurityConfig {
                 .requestMatchers("/",
                     "/swagger-ui/**",
                     "/v3/api-docs/**").permitAll()
-                // 로그인, 회원가입
-                .requestMatchers("/api/auth/login", "/api/members/join"
+                // 로그인, 회원가입, 토큰 재발행
+                .requestMatchers("/api/auth/login", "/api/members/join", "/api/auth/reissue"
                     ).permitAll()
                 .requestMatchers("/api/members/check", "/api/auth/logout").hasRole("USER")
                 .anyRequest().authenticated()

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -1,6 +1,7 @@
 package com.org.candoit.global.security.filter;
 
 import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.security.basic.CustomUserDetails;
 import com.org.candoit.global.security.jwt.JwtUtil;
 import com.org.candoit.global.security.jwt.TokenErrorCode;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -12,11 +13,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private static final String EXCEPTION_ATTRIBUTE = "exception";
@@ -25,7 +28,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final Set<String> excludeAllPaths = Set.of(
         "/swagger-ui/**", "/v3/api-docs/**",
-        "/api/auth/login", "/api/members/join"
+        "/api/auth/login", "/api/members/join", "/api/auth/reissue"
     );
 
     public JwtAuthorizationFilter(JwtUtil jwtUtil) {
@@ -66,6 +69,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
         }
 
         Authentication authentication = jwtUtil.getAuthentication(accessToken);
+        log.info("로그인한 사용자: {}", ((CustomUserDetails)authentication.getPrincipal()).getMember().getNickname());
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/org/candoit/global/security/jwt/JwtService.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/JwtService.java
@@ -1,9 +1,17 @@
 package com.org.candoit.global.security.jwt;
 
+import com.org.candoit.domain.auth.dto.NewTokenResponse;
+import com.org.candoit.domain.auth.exception.AuthErrorCode;
+import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.response.GlobalErrorCode;
+import com.org.candoit.global.security.basic.CustomUserDetails;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -14,6 +22,47 @@ public class JwtService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
     private final RedisTemplate<String, String> redisTemplate;
+
+    public NewTokenResponse reissue(String accessToken, String refreshToken) {
+        log.info("accessToken: {} refreshToken: {}", accessToken, refreshToken);
+        String extractAccessToken = jwtUtil.removePrefixFromAccessToken(accessToken);
+
+        Claims claimsAccessToken = jwtUtil.extractClaimsOrThrow("accessToken", extractAccessToken);
+        Claims claimsRefreshToken = jwtUtil.extractClaimsOrThrow("refreshToken", refreshToken);
+
+        String memberIdFromAccessToken = claimsAccessToken.getSubject();
+        String memberIdFromRefreshToken = claimsRefreshToken.getSubject();
+
+        if (!memberIdFromRefreshToken.equals(memberIdFromAccessToken)) {
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+
+        if (jwtUtil.checkBlacklist(extractAccessToken)) {
+            logout(accessToken);
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+
+        jwtUtil.validateAccessTokenExpiration(claimsAccessToken, extractAccessToken);
+
+        String existingRefreshToken = refreshTokenRepository.findByMemberId(
+            memberIdFromRefreshToken);
+        if (existingRefreshToken == null) {
+            throw new CustomException(AuthErrorCode.UNAUTHORIZED);
+        }
+
+        Authentication authentication = jwtUtil.getAuthentication(refreshToken);
+        String newAccessToken = jwtUtil.generateAccessToken(authentication);
+        String newRefreshToken = jwtUtil.generateRefreshToken(authentication);
+
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+        Authentication newAuthentication = new UsernamePasswordAuthenticationToken(
+            customUserDetails, null, customUserDetails.getAuthorities());
+
+        log.info("jwtService: 로그인한 사용자: {}", ((CustomUserDetails)newAuthentication.getPrincipal()).getMember().getNickname());
+        SecurityContextHolder.getContext().setAuthentication(newAuthentication);
+
+        return new NewTokenResponse(newAccessToken, newRefreshToken);
+    }
 
     public void logout(String accessToken) {
 
@@ -27,4 +76,6 @@ public class JwtService {
             refreshTokenRepository.delete(claimsAccessToken.getSubject());
         }
     }
+
+
 }

--- a/src/main/java/com/org/candoit/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/org/candoit/global/security/jwt/JwtUtil.java
@@ -120,6 +120,14 @@ public class JwtUtil {
                 TimeUnit.SECONDS);
     }
 
+    public void validateAccessTokenExpiration(Claims accessTokenClaims, String accessToken) {
+        Date accessTokenExpirationDate = accessTokenClaims.getExpiration();
+
+        if(accessTokenExpirationDate.after(new Date())) {
+            addBlackListExistingAccessToken(accessToken, accessTokenExpirationDate);
+        }
+    }
+
     public Authentication getAuthentication(String token) {
 
         String memberId = parseToken(token).getSubject();


### PR DESCRIPTION
## 📌이슈 번호
- #18 

## 👩🏻‍💻구현 내용
### 토큰 재발행
액세스 토큰이 만료됐을 경우, 리프레시 토큰을 통해 로그인 상태를 유지하기 위해 토큰 재발행을 구현했습니다.
따라서, 토큰 재발행 경로의 접근인 경우, JwtAuthorizationFilter를 거치지 않도록 구현했습니다. 