### PR TITLE
chore: 목데이터 생성

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/entity/DailyAction.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/entity/DailyAction.java
@@ -2,6 +2,7 @@ package com.org.candoit.domain.dailyaction.entity;
 
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,7 +33,7 @@ public class DailyAction {
 
     private Boolean isStore;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_goal_id")
     private SubGoal subGoal;
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionRepository.java
@@ -1,0 +1,8 @@
+package com.org.candoit.domain.dailyaction.repository;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyActionRepository extends JpaRepository<DailyAction, Long> {
+
+}

--- a/src/main/java/com/org/candoit/domain/dailyprogress/entity/DailyProgress.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/entity/DailyProgress.java
@@ -29,8 +29,6 @@ public class DailyProgress extends BaseTimeEntity {
 
     private LocalDate checkedDate;
 
-    private Boolean isChecked;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "daily_action_id")
     private DailyAction dailyAction;

--- a/src/main/java/com/org/candoit/domain/dailyprogress/entity/DailyProgress.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/entity/DailyProgress.java
@@ -3,11 +3,13 @@ package com.org.candoit.domain.dailyprogress.entity;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +27,11 @@ public class DailyProgress extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long dailyProgressId;
 
-    @ManyToOne
+    private LocalDate checkedDate;
+
+    private Boolean isChecked;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "daily_action_id")
     private DailyAction dailyAction;
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressRepository.java
@@ -1,0 +1,8 @@
+package com.org.candoit.domain.dailyprogress.repository;
+
+import com.org.candoit.domain.dailyprogress.entity.DailyProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyProgressRepository extends JpaRepository<DailyProgress, Long> {
+
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
@@ -3,6 +3,7 @@ package com.org.candoit.domain.maingoal.entity;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -27,15 +28,15 @@ public class MainGoal extends BaseTimeEntity {
 
     private String mainGoalName;
 
-    private Boolean isStore;
+    private Boolean isRepresentative;
 
-    private Boolean isRep;
+    private MainGoalStatus mainGoalStatus;
 
     private Integer lastAchievementRate;
 
     private Integer thisAchievementRate;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoalStatus.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoalStatus.java
@@ -1,0 +1,10 @@
+package com.org.candoit.domain.maingoal.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum MainGoalStatus {
+    ACTIVITY,
+    ATTAINMENT,
+    PAUSE
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalRepository.java
@@ -1,0 +1,8 @@
+package com.org.candoit.domain.maingoal.repository;
+
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MainGoalRepository extends JpaRepository<MainGoal, Long> {
+
+}

--- a/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
@@ -3,9 +3,7 @@ package com.org.candoit.domain.member.repository;
 import com.org.candoit.domain.member.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
-@Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -16,7 +16,7 @@ import com.org.candoit.global.response.GlobalErrorCode;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberService {
 
     private final MemberRepository memberRepository;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, String> redisTemplate;
 
     public void join(MemberJoinRequest memberJoinRequest){
@@ -34,7 +34,7 @@ public class MemberService {
         Member saveRequestMember = Member.builder()
             .email(memberJoinRequest.getEmail())
             .comment("안녕하세요.")
-            .password(bCryptPasswordEncoder.encode(memberJoinRequest.getPassword()))
+            .password(passwordEncoder.encode(memberJoinRequest.getPassword()))
             .nickname(memberJoinRequest.getNickname())
             .memberStatus(MemberStatus.ACTIVITY)
             .memberRole(MemberRole.ROLE_USER)
@@ -73,12 +73,12 @@ public class MemberService {
     public void updatePassword(Long memberId, NewPasswordRequest newPasswordRequest){
         checkVerify(memberId, "new-password");
         Member loginMember = memberRepository.findById(memberId).orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
-        loginMember.updatePassword(bCryptPasswordEncoder.encode(newPasswordRequest.getNewPassword()));
+        loginMember.updatePassword(passwordEncoder.encode(newPasswordRequest.getNewPassword()));
     }
 
     public void checkPassword(Member loginMember, CheckPasswordRequest checkPasswordRequest){
         String prefix = "check-password:"+checkPasswordRequest.getType()+":";
-        if(bCryptPasswordEncoder.matches(checkPasswordRequest.getPassword(), loginMember.getPassword())){
+        if(passwordEncoder.matches(checkPasswordRequest.getPassword(), loginMember.getPassword())){
             redisTemplate.opsForValue().set(prefix + loginMember.getMemberId(),
                "checked",
                 Duration.ofMinutes(5));

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
@@ -1,9 +1,9 @@
 package com.org.candoit.domain.subgoal.entity;
 
 import com.org.candoit.domain.maingoal.entity.MainGoal;
-import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -30,11 +30,7 @@ public class SubGoal extends BaseTimeEntity {
 
     private Boolean isStore;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_goal_id")
     private MainGoal mainGoal;
-
-    @ManyToOne
-    @JoinColumn(name = "member_id")
-    private Member member;
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalRepository.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalRepository.java
@@ -1,0 +1,8 @@
+package com.org.candoit.domain.subgoal.repository;
+
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubGoalRepository extends JpaRepository<SubGoal, Long> {
+
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/entity/SubProgress.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/entity/SubProgress.java
@@ -3,11 +3,13 @@ package com.org.candoit.domain.subprogress.entity;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -25,7 +27,13 @@ public class SubProgress extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long subProgressId;
 
-    @ManyToOne
+    private LocalDate checkedDate;
+
+    private Integer checkedCount;
+
+    private Integer targetCount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_goal_id")
     private SubGoal subGoal;
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressRepository.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressRepository.java
@@ -1,0 +1,8 @@
+package com.org.candoit.domain.subprogress.repository;
+
+import com.org.candoit.domain.subprogress.entity.SubProgress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubProgressRepository extends JpaRepository<SubProgress, Long> {
+
+}

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -31,13 +32,13 @@ public class SecurityConfig {
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
-    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
     @Bean
     public CustomAuthenticationProvider customAuthenticationProvider() {
-        return new CustomAuthenticationProvider(customUserDetailsService, bCryptPasswordEncoder());
+        return new CustomAuthenticationProvider(customUserDetailsService, passwordEncoder());
     }
 
     @Bean

--- a/src/main/java/com/org/candoit/global/security/CustomAuthenticationProvider.java
+++ b/src/main/java/com/org/candoit/global/security/CustomAuthenticationProvider.java
@@ -5,20 +5,19 @@ import com.org.candoit.global.response.CustomException;
 import com.org.candoit.global.security.basic.CustomUserDetails;
 import com.org.candoit.global.security.basic.CustomUserDetailsService;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 @RequiredArgsConstructor
 public class CustomAuthenticationProvider implements AuthenticationProvider {
 
     private final CustomUserDetailsService customUserDetailsService;
-    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public boolean supports(Class<?> authentication) {
@@ -42,7 +41,7 @@ public class CustomAuthenticationProvider implements AuthenticationProvider {
             throw new CustomException(MemberErrorCode.WITHDRAWN_MEMBER);
         }
 
-        if(password != null && !bCryptPasswordEncoder.matches(password, customUserDetails.getPassword())) {
+        if(password != null && !passwordEncoder.matches(password, customUserDetails.getPassword())) {
             throw new CustomException(MemberErrorCode.NOT_FOUND_MEMBER);
         }
 

--- a/src/main/java/com/org/candoit/init/MockDataLoader.java
+++ b/src/main/java/com/org/candoit/init/MockDataLoader.java
@@ -1,4 +1,3 @@
-/*
 package com.org.candoit.init;
 
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
@@ -196,19 +195,16 @@ public class MockDataLoader implements ApplicationRunner {
         DailyProgress mockDailyProgress1 = DailyProgress.builder()
             .dailyAction(mockDailyAction3)
             .checkedDate(LocalDate.of(2025,5,1))
-            .isChecked(Boolean.TRUE)
             .build();
 
         DailyProgress mockDailyProgress2 = DailyProgress.builder()
             .dailyAction(mockDailyAction4)
             .checkedDate(LocalDate.of(2025,5,3))
-            .isChecked(Boolean.TRUE)
             .build();
 
         DailyProgress mockDailyProgress3 = DailyProgress.builder()
             .dailyAction(mockDailyAction6)
             .checkedDate(LocalDate.of(2025,5,5))
-            .isChecked(Boolean.TRUE)
             .build();
 
         dailyProgressRepository.save(mockDailyProgress1);
@@ -219,4 +215,3 @@ public class MockDataLoader implements ApplicationRunner {
         log.info("목 데이터 삽입 종료");
     }
 }
-*/

--- a/src/main/java/com/org/candoit/init/MockDataLoader.java
+++ b/src/main/java/com/org/candoit/init/MockDataLoader.java
@@ -1,3 +1,4 @@
+/*
 package com.org.candoit.init;
 
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
@@ -218,3 +219,4 @@ public class MockDataLoader implements ApplicationRunner {
         log.info("목 데이터 삽입 종료");
     }
 }
+*/

--- a/src/main/java/com/org/candoit/init/MockDataLoader.java
+++ b/src/main/java/com/org/candoit/init/MockDataLoader.java
@@ -1,3 +1,4 @@
+/*
 package com.org.candoit.init;
 
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
@@ -215,3 +216,4 @@ public class MockDataLoader implements ApplicationRunner {
         log.info("목 데이터 삽입 종료");
     }
 }
+*/

--- a/src/main/java/com/org/candoit/init/MockDataLoader.java
+++ b/src/main/java/com/org/candoit/init/MockDataLoader.java
@@ -1,0 +1,220 @@
+package com.org.candoit.init;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.dailyprogress.entity.DailyProgress;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import com.org.candoit.domain.maingoal.repository.MainGoalRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberRole;
+import com.org.candoit.domain.member.entity.MemberStatus;
+import com.org.candoit.domain.member.repository.MemberRepository;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import com.org.candoit.domain.subprogress.entity.SubProgress;
+import com.org.candoit.domain.subprogress.repository.SubProgressRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MockDataLoader implements ApplicationRunner {
+
+    private final MemberRepository memberRepository;
+    private final MainGoalRepository mainGoalRepository;
+    private final DailyActionRepository dailyActionRepository;
+    private final DailyProgressRepository dailyProgressRepository;
+    private final SubGoalRepository subGoalRepository;
+    private final SubProgressRepository subProgressRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+
+        log.info("목 데이터 삽입 시작");
+        // Member
+        Member mockMember1 = Member.builder()
+            .email("test@email.com")
+            .memberRole(MemberRole.ROLE_USER)
+            .memberStatus(MemberStatus.ACTIVITY)
+            .comment("한줄 소개입니다.")
+            .password(passwordEncoder.encode("testtest"))
+            .nickname("zzuharchive")
+            .profilePath("profile.jpg")
+            .build();
+
+        memberRepository.save(mockMember1);
+
+        // MainGoal
+        MainGoal mockMainGoal1 = MainGoal.builder()
+            .member(mockMember1)
+            .lastAchievementRate(27)
+            .thisAchievementRate(37)
+            .mainGoalName("다이어트 하기")
+            .mainGoalStatus(MainGoalStatus.ACTIVITY)
+            .isRepresentative(Boolean.TRUE)
+            .build();
+
+        mainGoalRepository.save(mockMainGoal1);
+
+        // SubGoal
+        SubGoal mockSubGoal1 = SubGoal.builder()
+            .mainGoal(mockMainGoal1)
+            .subGoalTitle("유산소 하기")
+            .mainGoal(mockMainGoal1)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        SubGoal mockSubGoal2 = SubGoal.builder()
+            .mainGoal(mockMainGoal1)
+            .subGoalTitle("식단하기")
+            .mainGoal(mockMainGoal1)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        SubGoal mockSubGoal3 = SubGoal.builder()
+            .mainGoal(mockMainGoal1)
+            .subGoalTitle("근력운동하기")
+            .mainGoal(mockMainGoal1)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        subGoalRepository.save(mockSubGoal1);
+        subGoalRepository.save(mockSubGoal2);
+        subGoalRepository.save(mockSubGoal3);
+
+        // DailyAction
+        DailyAction mockDailyAction1 = DailyAction.builder()
+            .subGoal(mockSubGoal1)
+            .dailyActionTitle("러닝머신 달리기")
+            .content("인터벌로 달리기 최소 30분")
+            .targetNum(4)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction2 = DailyAction.builder()
+            .subGoal(mockSubGoal1)
+            .dailyActionTitle("걷기")
+            .content("피크민하면서 산책하기")
+            .targetNum(3)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction3 = DailyAction.builder()
+            .subGoal(mockSubGoal2)
+            .dailyActionTitle("물 마시기")
+            .content("물 1L 마시기")
+            .targetNum(7)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction4 = DailyAction.builder()
+            .subGoal(mockSubGoal2)
+            .dailyActionTitle("영양제 먹기")
+            .content("유산균, 비타민C, 콜라겐")
+            .targetNum(7)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction5 = DailyAction.builder()
+            .subGoal(mockSubGoal2)
+            .dailyActionTitle("단백질 챙겨먹기")
+            .content("단백질 40g 챙기기!")
+            .targetNum(7)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction6 = DailyAction.builder()
+            .subGoal(mockSubGoal3)
+            .dailyActionTitle("등, 어깨, 삼두")
+            .content("상체")
+            .targetNum(2)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction7 = DailyAction.builder()
+            .subGoal(mockSubGoal3)
+            .dailyActionTitle("이두, 가슴")
+            .content("상체")
+            .targetNum(1)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        DailyAction mockDailyAction8 = DailyAction.builder()
+            .subGoal(mockSubGoal3)
+            .dailyActionTitle("하체")
+            .content("하체")
+            .targetNum(3)
+            .isStore(Boolean.FALSE)
+            .build();
+
+        dailyActionRepository.save(mockDailyAction1);
+        dailyActionRepository.save(mockDailyAction2);
+        dailyActionRepository.save(mockDailyAction3);
+        dailyActionRepository.save(mockDailyAction4);
+        dailyActionRepository.save(mockDailyAction5);
+        dailyActionRepository.save(mockDailyAction6);
+        dailyActionRepository.save(mockDailyAction7);
+        dailyActionRepository.save(mockDailyAction8);
+
+
+        // SubProgress
+        SubProgress mockSubProgress1 = SubProgress.builder()
+            .subGoal(mockSubGoal2)
+            .checkedDate(LocalDate.of(2025,5,3))
+            .targetCount(21)
+            .checkedCount(1)
+            .build();
+        SubProgress mockSubProgress2 = SubProgress.builder()
+            .subGoal(mockSubGoal2)
+            .checkedDate(LocalDate.of(2025,5,3))
+            .targetCount(21)
+            .checkedCount(2)
+            .build();
+        SubProgress mockSubProgress3 = SubProgress.builder()
+            .subGoal(mockSubGoal3)
+            .checkedDate(LocalDate.of(2025,5,3))
+            .targetCount(1)
+            .checkedCount(6)
+            .build();
+
+
+        subProgressRepository.save(mockSubProgress1);
+        subProgressRepository.save(mockSubProgress2);
+        subProgressRepository.save(mockSubProgress3);
+
+        // DailyProgress
+        DailyProgress mockDailyProgress1 = DailyProgress.builder()
+            .dailyAction(mockDailyAction3)
+            .checkedDate(LocalDate.of(2025,5,1))
+            .isChecked(Boolean.TRUE)
+            .build();
+
+        DailyProgress mockDailyProgress2 = DailyProgress.builder()
+            .dailyAction(mockDailyAction4)
+            .checkedDate(LocalDate.of(2025,5,3))
+            .isChecked(Boolean.TRUE)
+            .build();
+
+        DailyProgress mockDailyProgress3 = DailyProgress.builder()
+            .dailyAction(mockDailyAction6)
+            .checkedDate(LocalDate.of(2025,5,5))
+            .isChecked(Boolean.TRUE)
+            .build();
+
+        dailyProgressRepository.save(mockDailyProgress1);
+        dailyProgressRepository.save(mockDailyProgress2);
+        dailyProgressRepository.save(mockDailyProgress3);
+
+
+        log.info("목 데이터 삽입 종료");
+    }
+}


### PR DESCRIPTION
## 📌이슈 번호
- #22 

## 👩🏻‍💻구현 내용
### 목 데이터 생성
원활한 개발을 위해 목 데이터를 생성해주었습니다.
ApplicationRunner는 시작시점에 특정한 로직을 실행시킬 수 있도록 하는 인터페이스로, 해당 인터페이스를 구현하여 MockDataLoader를 작성했습니다. 이후에는 사용하지 않기 때문에 주석으로 처리 해주었습니다.
### 엔티티 수정
- **fetchJoin 옵션을 Lazy로 설정**
연관관계 설정 시, FetchJoin 설정을 지정하지 않아 기본 옵션인 Eager로 설정되어 있었습니다.
Eager는 연관된 모든 엔티티를 가져온다는 장점이 있습니다. 그러나, 즉시 로딩을 진행하기 때문에 **연관 관계가 필요 없는 경우에도 데이터를 항상 조회**해서 성능 문제가 발생할 수 있습니다. 또한, 즉시 로딩은 outer join을 사용하여 항상 연관 데이터를 함께 조회하는데, 이는 불필요한 데이터 조회와 성능 저하로 이어질 수 있습니다. 이를 방지하기 위해 지연 로딩(Lazy)으로 설정하였습니다.

- **SubGoal과 Member의 직접적인 연관관계 제거**
이전에는 SubGoal에 Member와 직접적으로 연관관계를 맺고 있었습니다. 그러나, SubGoal에서는 MainGoal과 연관관계를 맺고 있었고, MainGoal 내부에 이미 Member가 존재했기 때문에, SubGoal에 Member가 중복적으로 존재하게 됩니다. 따라서, SubGoal에 Member를 제거하여 이런 문제를 해결했습니다.

- **SubProgress와 DailyProgress**
기존에는 BaseEntity에 있는 createdAt 필드를 통해 선택한 날짜를 확인하려고 했습니다. 그런데 이는 사용자가 주말에 몰아서 다른 날짜의 `DailyAction`를 선택하는 것을 고려하지 못한 설계였습니다. 따라서, checkedDate를 통해 사용자가 체크한 날짜를 선택할 수 있도록 했습니다.  
    - SubProgress
       - **checkedCount**
       SubGoal에 해당하는 dailyAction에 대해 체크한 숫자를 기록합니다.
       - **targetCount**
       SubGoal에 해당하는 dailyAction들에 대한 targetCount의 총 합입니다.
    두 개의 필드를 사용해 진행도를 계산합니다.

- **MainGoalStatus를 enum 상태로 관리**
MainGoal은 활성, 비활성(보관 상태), 달성 상태를 가질 수 있습니다. enum은 가독성이 좋고, 관리가 편하다는 장점이 있으며, 특정 범위의 값만 사용할 수 있으므로 런타임 예외를 줄일 수 있습니다.
대표 속성은 메인 골 중 하나만 지정할 수 있으므로, Boolean 타입으로 작성했습니다.

### BCryptPasswordEncoder에서 PasswordEncoder로 변경
PasswordEncoder는 interface이며, BCryptPasswordEncoder는 그 구현체입니다.  
기존에는 구현체에 직접 의존했기 때문에, 암호화 방식이 변경될 경우 서비스 코드 수정이 불가피했습니다.
현재로선 변경 계획은 없지만, 구조의 유연성과 유지보수를 고려하여 PasswordEncoder 인터페이스에 의존하도록 변경하였습니다

## 📸 스크린샷
✅목 데이터 삽입 성공
![image](https://github.com/user-attachments/assets/3bd266c0-bdbe-4a46-8e92-9ab9a87bdafd)
![image](https://github.com/user-attachments/assets/ff414f83-7945-45fc-a69e-b8e074ee5045)
