### PR TITLE
feature: 메인골 생성 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -1,0 +1,33 @@
+package com.org.candoit.domain.maingoal.controller;
+
+import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
+import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
+import com.org.candoit.domain.maingoal.service.MainGoalService;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.annotation.LoginMember;
+import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/main-goals")
+public class MainGoalController {
+
+    private final MainGoalService mainGoalService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MainGoalResponse>> createMainGoal(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @RequestBody CreateMainGoalRequest createMainGoalRequest) {
+        MainGoalResponse mainGoalResponse = mainGoalService.createMainGoal(member, createMainGoalRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(ApiResponse.success(mainGoalResponse));
+    }
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalRequest.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import java.util.ArrayList;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateMainGoalRequest {
+    private String mainGoalName;
+    private ArrayList<String> subGoalName;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalResponse.java
@@ -1,0 +1,15 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MainGoalResponse {
+
+    private Long mainGoalId;
+    private String mainGoalName;
+    private Boolean isRepresentative;
+    private MainGoalStatus mainGoalStatus;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -1,0 +1,61 @@
+package com.org.candoit.domain.maingoal.service;
+
+import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
+import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import com.org.candoit.domain.maingoal.repository.MainGoalRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.entity.Color;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class MainGoalService {
+
+    private final MainGoalRepository mainGoalRepository;
+    private final SubGoalRepository subGoalRepository;
+
+    public MainGoalResponse createMainGoal(Member member, CreateMainGoalRequest request) {
+
+        MainGoal mainGoal = MainGoal.builder()
+            .member(member)
+            .mainGoalName(request.getMainGoalName())
+            .mainGoalStatus(MainGoalStatus.ACTIVITY)
+            .thisAchievementRate(0)
+            .lastAchievementRate(0)
+            .isRepresentative(Boolean.FALSE)
+            .build();
+
+        MainGoal savedMainGoal = mainGoalRepository.save(mainGoal);
+
+        if(!request.getSubGoalName().isEmpty()){
+            ArrayList<SubGoal> subGoals = new ArrayList<>();
+
+            for (int i = 0; i < request.getSubGoalName().size(); i++) {
+                SubGoal subGoal = SubGoal.builder()
+                    .mainGoal(mainGoal)
+                    .subGoalTitle(request.getSubGoalName().get(i))
+                    .color(Color.getColor(i))
+                    .isStore(Boolean.FALSE)
+                    .build();
+                subGoals.add(subGoal);
+            }
+
+            subGoalRepository.saveAll(subGoals);
+        }
+
+        return MainGoalResponse.builder()
+            .mainGoalId(savedMainGoal.getMainGoalId())
+            .mainGoalStatus(savedMainGoal.getMainGoalStatus())
+            .mainGoalName(savedMainGoal.getMainGoalName())
+            .isRepresentative(savedMainGoal.getIsRepresentative())
+            .build();
+    }
+}

--- a/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
+++ b/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
@@ -29,8 +29,8 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(){
-        MyPageResponse myPageResponse = memberService.getMyPage(4l);
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(@Parameter(hidden = true) @LoginMember Member loginMember){
+        MyPageResponse myPageResponse = memberService.getMyPage(loginMember.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(myPageResponse));
     }
 

--- a/src/main/java/com/org/candoit/domain/member/dto/MyPageResponse.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/MyPageResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 public class MyPageResponse {
 
-    private String profile_image;
+    private String profileImage;
     private String comment;
     private String email;
     private String nickname;

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -15,6 +15,8 @@ import com.org.candoit.global.response.CustomException;
 import com.org.candoit.global.response.GlobalErrorCode;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -25,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class MemberService {
 
+    private static final Logger log = LoggerFactory.getLogger(MemberService.class);
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final RedisTemplate<String, String> redisTemplate;
@@ -63,7 +66,7 @@ public class MemberService {
             MemberErrorCode.NOT_FOUND_MEMBER));
 
         return MyPageResponse.builder()
-            .profile_image(member.getProfilePath())
+            .profileImage(member.getProfilePath())
             .comment(member.getComment())
             .email(member.getEmail())
             .nickname(member.getNickname())
@@ -105,7 +108,7 @@ public class MemberService {
             memberUpdateRequest.getComment(), memberUpdateRequest.getProfile_image());
 
         return MyPageResponse.builder()
-            .profile_image(memberUpdateRequest.getProfile_image())
+            .profileImage(memberUpdateRequest.getProfile_image())
             .comment(memberUpdateRequest.getComment())
             .email(memberUpdateRequest.getEmail())
             .nickname(memberUpdateRequest.getNickname())

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/Color.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/Color.java
@@ -5,16 +5,25 @@ import lombok.Getter;
 @Getter
 public enum Color {
 
-    COLOR_4091EE(0x4091EE),
-    COLOR_70CCB1(0x70CCB1),
-    COLOR_7BBFF9(0x7BBFF9),
-    COLOR_8C80DD(0x8C80DD),
-    COLOR_B1D854(0xB1D854),
-    COLOR_EB4335(0xEB4335),
-    COLOR_F09725(0xF09725),
-    COLOR_F7D04D(0xF7D04D);
+    COLOR_1(0x4091EE),
+    COLOR_2(0x70CCB1),
+    COLOR_3(0x7BBFF9),
+    COLOR_4(0x8C80DD),
+    COLOR_5(0xB1D854),
+    COLOR_6(0xEB4335),
+    COLOR_7(0xF09725),
+    COLOR_8(0xF7D04D);
 
     private final int hexValue;
 
     Color(int hexValue) {this.hexValue = hexValue;}
+
+    public static Color getColor(int index) {
+        Color[] colors = values();
+        return colors[index];
+    }
+
+    public int getHexValue() {
+        return hexValue;
+    }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
@@ -3,6 +3,8 @@ package com.org.candoit.domain.subgoal.entity;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -29,6 +31,9 @@ public class SubGoal extends BaseTimeEntity {
     private String subGoalTitle;
 
     private Boolean isStore;
+
+    @Enumerated(EnumType.STRING)
+    private Color color;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_goal_id")

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
                 // 로그인, 회원가입, 토큰 재발행
                 .requestMatchers("/api/auth/login", "/api/members/join", "/api/auth/reissue"
                     ).permitAll()
-                .requestMatchers("/api/members/check", "/api/auth/logout").hasRole("USER")
+                .requestMatchers("/api/members/check", "/api/auth/logout", "/api/main-goals").hasRole("USER")
                 .anyRequest().authenticated()
             );
 

--- a/src/main/java/com/org/candoit/init/MockDataLoader.java
+++ b/src/main/java/com/org/candoit/init/MockDataLoader.java
@@ -54,7 +54,7 @@ public class MockDataLoader implements ApplicationRunner {
 
         memberRepository.save(mockMember1);
 
-        // MainGoal
+    // MainGoal
         MainGoal mockMainGoal1 = MainGoal.builder()
             .member(mockMember1)
             .lastAchievementRate(27)


### PR DESCRIPTION
## 📌이슈 번호
- #24 

## 👩🏻‍💻구현 내용
### 메인골 생성 기능 구현
메인골 생성 기능을 구현했습니다.
MainGoalStatus는 ACTIVITY, isRepresentative는 FALSE 값을 기본으로 가질 수 있도록 설정했습니다.

### 서브골의 Color 필드 추가
SubGoal 엔티티에 Color 필드를 추가했습니다. 추후, 프론트 측에서 색상을 변경 할 가능성을 고려하여 DB에는 COLOR_1, COLOR_2와 같은 값이 저장될 수 있도록 했습니다. 응답 시, getHexValue 메서드를 사용하여 Hex 값을 반환할 계획입니다.

### MyPageResponse의 profile_image를 profileImage로 변경
자바에서는 보통 카멜 케이스에 따라 작성하므로 profileImage로 변경해주었습니다.  
그러나, json은 스네이크 케이스를 따르므로 applicaiton.yml 파일에 다음 설정을 추가해주었습니다.
```yml
  jackson:
    property-naming-strategy: SNAKE_CASE
```