### PR TITLE
feature: 메인골 삭제기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,11 @@ dependencies {
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-
-
     runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     // Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -54,6 +56,16 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+}
+
+def querydslDir = "build/generated/querydsl";
+
+tasks.withType(JavaCompile){
+    options.generatedSourceOutputDirectory = file(querydslDir)
+}
+
+clean {
+    delete file(querydslDir)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,8 +28,17 @@ public class MainGoalController {
     public ResponseEntity<ApiResponse<MainGoalResponse>> createMainGoal(
         @Parameter(hidden = true) @LoginMember Member member,
         @RequestBody CreateMainGoalRequest createMainGoalRequest) {
-        MainGoalResponse mainGoalResponse = mainGoalService.createMainGoal(member, createMainGoalRequest);
+        MainGoalResponse mainGoalResponse = mainGoalService.createMainGoal(member,
+            createMainGoalRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.success(mainGoalResponse));
+    }
+
+    @DeleteMapping("{mainGoalId}")
+    public ResponseEntity<ApiResponse<Boolean>> deleteMainGoal(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @PathVariable Long mainGoalId) {
+        Boolean result = mainGoalService.deleteMainGoal(member, mainGoalId);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalResponse.java
@@ -1,6 +1,8 @@
 package com.org.candoit.domain.maingoal.dto;
 
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import com.org.candoit.domain.subgoal.dto.SubGoalResponse;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -12,4 +14,5 @@ public class MainGoalResponse {
     private String mainGoalName;
     private Boolean isRepresentative;
     private MainGoalStatus mainGoalStatus;
+    private List<SubGoalResponse> subGoals;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
@@ -1,7 +1,9 @@
 package com.org.candoit.domain.maingoal.entity;
 
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.global.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -9,6 +11,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -39,4 +44,7 @@ public class MainGoal extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "mainGoal", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<SubGoal> subGoals = new ArrayList<>();
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/exception/MainGoalErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/exception/MainGoalErrorCode.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.maingoal.exception;
+
+import com.org.candoit.global.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MainGoalErrorCode implements ErrorCode {
+    NOT_FOUND_MAIN_GOAL(HttpStatus.NOT_FOUND, "20000", "일치하는 메인 골을 찾지 못했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
@@ -1,0 +1,9 @@
+package com.org.candoit.domain.maingoal.repository;
+
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import java.util.Optional;
+
+public interface MainGoalCustomRepository {
+
+    Optional<MainGoal> findByMainGoalIdAndMemberId(Long mainGoalId, Long memberId);
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
@@ -1,0 +1,26 @@
+package com.org.candoit.domain.maingoal.repository;
+
+import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
+import static com.org.candoit.domain.member.entity.QMember.member;
+
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Optional<MainGoal> findByMainGoalIdAndMemberId(Long mainGoalId, Long memberId) {
+        return Optional.ofNullable(jpaQueryFactory.select(mainGoal)
+            .from(mainGoal)
+            .innerJoin(member)
+            .on(mainGoal.member.memberId.eq(memberId))
+            .where(mainGoal.mainGoalId.eq(mainGoalId)).fetchOne());
+    }
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MainGoalRepository extends JpaRepository<MainGoal, Long> {
 
+
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -4,12 +4,17 @@ import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
+import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
 import com.org.candoit.domain.maingoal.repository.MainGoalRepository;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.SubGoalResponse;
 import com.org.candoit.domain.subgoal.entity.Color;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import com.org.candoit.global.response.CustomException;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MainGoalService {
 
     private final MainGoalRepository mainGoalRepository;
+    private final MainGoalCustomRepository mainGoalCustomRepository;
     private final SubGoalRepository subGoalRepository;
 
     public MainGoalResponse createMainGoal(Member member, CreateMainGoalRequest request) {
@@ -34,28 +40,50 @@ public class MainGoalService {
             .build();
 
         MainGoal savedMainGoal = mainGoalRepository.save(mainGoal);
+        ArrayList<SubGoalResponse> subGoalResponses = new ArrayList<>();
 
-        if(!request.getSubGoalName().isEmpty()){
+        if (!request.getSubGoalName().isEmpty()) {
             ArrayList<SubGoal> subGoals = new ArrayList<>();
 
             for (int i = 0; i < request.getSubGoalName().size(); i++) {
                 SubGoal subGoal = SubGoal.builder()
                     .mainGoal(mainGoal)
-                    .subGoalTitle(request.getSubGoalName().get(i))
+                    .subGoalName(request.getSubGoalName().get(i))
                     .color(Color.getColor(i))
                     .isStore(Boolean.FALSE)
                     .build();
                 subGoals.add(subGoal);
             }
 
-            subGoalRepository.saveAll(subGoals);
+            List<SubGoal> subGoalList = subGoalRepository.saveAll(subGoals);
+            for (SubGoal subGoal : subGoalList) {
+                SubGoalResponse subGoalResponse = SubGoalResponse.builder()
+                    .subGoalId(subGoal.getSubGoalId())
+                    .subGoalName(subGoal.getSubGoalName())
+                    .color(subGoal.getColor().getHexValue())
+                    .isStore(subGoal.getIsStore())
+                    .build();
+
+                subGoalResponses.add(subGoalResponse);
+            }
         }
+
 
         return MainGoalResponse.builder()
             .mainGoalId(savedMainGoal.getMainGoalId())
             .mainGoalStatus(savedMainGoal.getMainGoalStatus())
             .mainGoalName(savedMainGoal.getMainGoalName())
             .isRepresentative(savedMainGoal.getIsRepresentative())
+            .subGoals(subGoalResponses)
             .build();
+    }
+
+    public Boolean deleteMainGoal(Member loginMember, Long mainGoalId) {
+        MainGoal mainGoal = mainGoalCustomRepository.findByMainGoalIdAndMemberId(mainGoalId, loginMember.getMemberId())
+            .orElseThrow(() -> new CustomException(
+                MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
+
+        mainGoalRepository.delete(mainGoal);
+        return Boolean.TRUE;
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/SubGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/SubGoalResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubGoalResponse {
+
+    private Long subGoalId;
+    private String subGoalName;
+    private Boolean isStore;
+    private String color;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/Color.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/Color.java
@@ -1,29 +1,29 @@
 package com.org.candoit.domain.subgoal.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public enum Color {
 
-    COLOR_1(0x4091EE),
-    COLOR_2(0x70CCB1),
-    COLOR_3(0x7BBFF9),
-    COLOR_4(0x8C80DD),
-    COLOR_5(0xB1D854),
-    COLOR_6(0xEB4335),
-    COLOR_7(0xF09725),
-    COLOR_8(0xF7D04D);
+    COLOR_1("0x4091EE"),
+    COLOR_2("0x70CCB1"),
+    COLOR_3("0x7BBFF9"),
+    COLOR_4("0x8C80DD"),
+    COLOR_5("0xB1D854"),
+    COLOR_6("0xEB4335"),
+    COLOR_7("0xF09725"),
+    COLOR_8("0xF7D04D");
 
-    private final int hexValue;
-
-    Color(int hexValue) {this.hexValue = hexValue;}
+    private final String hexValue;
 
     public static Color getColor(int index) {
         Color[] colors = values();
         return colors[index];
     }
 
-    public int getHexValue() {
+    public String getHexValue() {
         return hexValue;
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
@@ -28,7 +28,7 @@ public class SubGoal extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long subGoalId;
 
-    private String subGoalTitle;
+    private String subGoalName;
 
     private Boolean isStore;
 

--- a/src/main/java/com/org/candoit/global/config/QuerydslConfig.java
+++ b/src/main/java/com/org/candoit/global/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.org.candoit.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuerydslConfig {
+
+    private final EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #26 

## 👩🏻‍💻 구현 내용
### 연관 관계 수정
메인 골 하위에는 서브 골, 서브 골 하위에는 데일리 액션이 존재하는 구조를 가집니다. 따라서, 메인 골이 삭제되면, 하위의 다른 엔티티도 함께 삭제 되어야 합니다. 기존에는 다대일 단방향 연관관계를 맺고 있어, 상위 엔티티인 MainGoal이 하위 엔티티인 SubGoal의 존재를 알지 못하기 때문에 직접 레포지토리에 접근해서 데이터를 삭제 해야 했습니다.

(예시)
- `dailyActionRepository.deleteBySubGoalId(...)`,
- `subGoalRepository.deleteByMainGoalId(...)`,
- `mainGoalRepository.deleteById(...)`

여러 쿼리를 직접 작성해야 하고, 각 삭제가 JPA 트랜잭션 안에서 순차적으로 잘 이뤄지는지도 신경 써야 하다 보니, **비즈니스 로직이 복잡**해졌고, **DB와의 불필요한 통신도 많아질 수 있다는 우려**가 생겼습니다. 따라서, **양방향 연관관계로 수정**했습니다. 
MainGoal에서 cascade와 orphanRemoval 옵션을 설정해주었습니다. cascade는 `CascadeType.All`과 `CascadeType.Remove` 중에서 고민했으나, 삽입(persist)까지 연관된 엔티티에 전파할 필요는 없다는 판단을 했습니다. 따라서, `CascadeType.Remove` 를 채택했습니다.

이번 이슈에서는 MainGoal과 SubGoal에 대해서만 수정했으나, 이후, 각각의 도메인을 구현하며 수정할 계획입니다.

### 메인골 삭제 기능 구현
메인골 삭제 기능을 구현했습니다. 양방향 연관관계를 통해 `mainGoalRepository.delete` 만으로 메인골과 서브골을 삭제 할 수 있게 되었습니다. 추후, 서브골과 데일리액션에 양방향 연관관계를 통해 삭제를 전파하면, 종속적인 성격을 갖는 서브골, 데일리 액션이 함께 삭제될 것입니다.

### 메인골 생성 응답 수정
기존에는 응답바디에 메인골에 관한 데이터만 반환했으나, 서브 골도 함께 생성한다는 점을 반영하여, **서브 골에 대한 데이터도 함께 반환**할 수 있도록 반영했습니다.