### PR TITLE
feature: 대표 메인골 설정 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -41,4 +41,12 @@ public class MainGoalController {
         Boolean result = mainGoalService.deleteMainGoal(member, mainGoalId);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
+
+    @PostMapping("{mainGoalId}/rep")
+    public ResponseEntity<ApiResponse<Boolean>> updateMainGoalRep(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @PathVariable Long mainGoalId) {
+        Boolean result = mainGoalService.updateMainGoalRep(member, mainGoalId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
@@ -5,6 +5,8 @@ import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.global.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -35,6 +37,7 @@ public class MainGoal extends BaseTimeEntity {
 
     private Boolean isRepresentative;
 
+    @Enumerated(EnumType.STRING)
     private MainGoalStatus mainGoalStatus;
 
     private Integer lastAchievementRate;
@@ -47,4 +50,12 @@ public class MainGoal extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "mainGoal", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<SubGoal> subGoals = new ArrayList<>();
+
+    public void uncheckRepresentation(){
+        this.isRepresentative = Boolean.FALSE;
+    }
+
+    public void checkRepresentation(){
+        this.isRepresentative = Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 public interface MainGoalCustomRepository {
 
     Optional<MainGoal> findByMainGoalIdAndMemberId(Long mainGoalId, Long memberId);
+    Optional<MainGoal> findRepresentativeMainGoalByMemberId(Long memberId);
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
@@ -23,4 +23,15 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             .on(mainGoal.member.memberId.eq(memberId))
             .where(mainGoal.mainGoalId.eq(mainGoalId)).fetchOne());
     }
+
+    @Override
+    public Optional<MainGoal> findRepresentativeMainGoalByMemberId(Long memberId) {
+        return Optional.ofNullable(jpaQueryFactory.select(mainGoal)
+            .from(mainGoal)
+            .innerJoin(member)
+            .on(mainGoal.member.memberId.eq(memberId))
+            .where(
+               (mainGoal.isRepresentative.eq(Boolean.TRUE)))
+            .fetchOne());
+    }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -18,12 +18,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @RequiredArgsConstructor
 @Service
+@Slf4j
 public class MainGoalService {
 
     private final MainGoalRepository mainGoalRepository;
@@ -84,5 +86,28 @@ public class MainGoalService {
 
         mainGoalRepository.delete(mainGoal);
         return Boolean.TRUE;
+    }
+
+    public Boolean updateMainGoalRep(Member loginMember, Long mainGoalId){
+
+        checkedAlreadyRep(loginMember.getMemberId());
+        MainGoal mainGoal = mainGoalCustomRepository.findByMainGoalIdAndMemberId(mainGoalId, loginMember.getMemberId())
+            .orElseThrow(() -> new CustomException(
+                MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
+        mainGoal.checkRepresentation();
+
+        return Boolean.TRUE;
+    }
+
+    private void checkedAlreadyRep(Long memberId) {
+        MainGoal mainGoal = mainGoalCustomRepository.findRepresentativeMainGoalByMemberId(memberId).orElse(null);
+
+        if (mainGoal != null) {
+            uncheckRepresentative(mainGoal);
+        }
+    }
+
+    private void uncheckRepresentative(MainGoal mainGoal) {
+        mainGoal.uncheckRepresentation();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #28 

## 👩🏻‍💻 구현 내용
### Problem
- 대표 메인골 설정 api 필요
### Approach
- 대표 메인골 설정 요청 처리 흐름
    ① 기존에 대표로 설정된 메인골이 있는지 확인
    ② 존재한다면 해당 메인골의 대표 설정을 해제
    ③ 새로 요청된 메인골을 대표 메인골로 설정