### PR TITLE
feature: 메인골 수정기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -2,6 +2,7 @@ package com.org.candoit.domain.maingoal.controller;
 
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
 import com.org.candoit.domain.maingoal.service.MainGoalService;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.annotation.LoginMember;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -40,5 +42,13 @@ public class MainGoalController {
         @PathVariable Long mainGoalId) {
         Boolean result = mainGoalService.deleteMainGoal(member, mainGoalId);
         return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("{mainGoalId}")
+    public ResponseEntity<ApiResponse<MainGoalResponse>> updateMainGoal(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @PathVariable Long mainGoalId, @RequestBody UpdateMainGoalRequest updateMainGoalRequest) {
+        MainGoalResponse mainGoalResponse = mainGoalService.updateMainGoal(member, mainGoalId, updateMainGoalRequest);
+        return ResponseEntity.ok(ApiResponse.success(mainGoalResponse));
     }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/UpdateMainGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/UpdateMainGoalRequest.java
@@ -1,0 +1,13 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class UpdateMainGoalRequest {
+
+    private String mainGoalName;
+    private MainGoalStatus mainGoalStatus;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
@@ -47,4 +47,9 @@ public class MainGoal extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "mainGoal", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<SubGoal> subGoals = new ArrayList<>();
+
+    public void updateMainGoal(String mainGoalName, MainGoalStatus mainGoalStatus){
+        this.mainGoalName = mainGoalName;
+        this.mainGoalStatus = mainGoalStatus;
+    }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -2,6 +2,7 @@ package com.org.candoit.domain.maingoal.service;
 
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
 import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
@@ -59,21 +60,12 @@ public class MainGoalService {
             savedSubGoals = subGoalRepository.saveAll(subGoals);
         }
 
-        List<SubGoalResponse> subGoalResponses = savedSubGoals.stream()
-            .map(savedSubGoal -> SubGoalResponse.builder()
-                .subGoalId(savedSubGoal.getSubGoalId())
-                .subGoalName(savedSubGoal.getSubGoalName())
-                .color(savedSubGoal.getColor().getHexValue())
-                .isStore(savedSubGoal.getIsStore())
-                .build())
-            .collect(Collectors.toList());
-
         return MainGoalResponse.builder()
             .mainGoalId(savedMainGoal.getMainGoalId())
             .mainGoalStatus(savedMainGoal.getMainGoalStatus())
             .mainGoalName(savedMainGoal.getMainGoalName())
             .isRepresentative(savedMainGoal.getIsRepresentative())
-            .subGoals(subGoalResponses)
+            .subGoals(createSubGoalResponse(savedSubGoals))
             .build();
     }
 
@@ -84,5 +76,32 @@ public class MainGoalService {
 
         mainGoalRepository.delete(mainGoal);
         return Boolean.TRUE;
+    }
+
+    public MainGoalResponse updateMainGoal(Member loginMember, Long mainGoalId, UpdateMainGoalRequest updateMainGoalRequest){
+        MainGoal mainGoal = mainGoalCustomRepository.findByMainGoalIdAndMemberId(mainGoalId, loginMember.getMemberId())
+            .orElseThrow(() -> new CustomException(
+                MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
+
+        mainGoal.updateMainGoal(updateMainGoalRequest.getMainGoalName(), updateMainGoalRequest.getMainGoalStatus());
+
+        return MainGoalResponse.builder()
+            .mainGoalId(mainGoal.getMainGoalId())
+            .mainGoalStatus(mainGoal.getMainGoalStatus())
+            .mainGoalName(mainGoal.getMainGoalName())
+            .isRepresentative(mainGoal.getIsRepresentative())
+            .subGoals(createSubGoalResponse(mainGoal.getSubGoals()))
+            .build();
+    }
+
+    private List<SubGoalResponse> createSubGoalResponse(List<SubGoal> subGoalList){
+        return subGoalList.stream()
+            .map(subGoal -> SubGoalResponse.builder()
+                .subGoalId(subGoal.getSubGoalId())
+                .subGoalName(subGoal.getSubGoalName())
+                .color(subGoal.getColor().getHexValue())
+                .isStore(subGoal.getIsStore())
+                .build())
+            .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #30 

## 👩🏻‍💻 구현 내용
### Problem
- 메인골 수정 api 필요

### Approach
- MainGoal 엔티티에 `updateMainGoal()` 메소드를 사용해 **더티 체킹**을 진행할 수 있도록 함.