### PR TITLE
fix: 메인골 생성 기능 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
@@ -1,0 +1,11 @@
+package com.org.candoit.domain.dailyaction.dto;
+
+import lombok.Getter;
+
+@Getter
+public class CreateDailyActionRequest {
+
+    private String dailyActionTitle;
+    private String dailyActionContent;
+    private Integer targetNum;
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public class CreateDailyActionRequest {
 
-    private String dailyActionTitle;
-    private String dailyActionContent;
+    private String title;
+    private String content;
     private Integer targetNum;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -1,6 +1,7 @@
 package com.org.candoit.domain.maingoal.controller;
 
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
+import com.org.candoit.domain.maingoal.dto.CreateMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
 import com.org.candoit.domain.maingoal.service.MainGoalService;
@@ -27,13 +28,13 @@ public class MainGoalController {
     private final MainGoalService mainGoalService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<MainGoalResponse>> createMainGoal(
+    public ResponseEntity<ApiResponse<CreateMainGoalResponse>> createMainGoal(
         @Parameter(hidden = true) @LoginMember Member member,
         @RequestBody CreateMainGoalRequest createMainGoalRequest) {
-        MainGoalResponse mainGoalResponse = mainGoalService.createMainGoal(member,
+        CreateMainGoalResponse createMainGoalResponse = mainGoalService.createMainGoal(member,
             createMainGoalRequest);
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ApiResponse.success(mainGoalResponse));
+            .body(ApiResponse.success(createMainGoalResponse));
     }
 
     @DeleteMapping("{mainGoalId}")

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalRequest.java
@@ -8,6 +8,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CreateMainGoalRequest {
-    private String mainGoalName;
+    private String name;
     private List<CreateSubGoalRequest> subGoals;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalRequest.java
@@ -1,6 +1,7 @@
 package com.org.candoit.domain.maingoal.dto;
 
-import java.util.ArrayList;
+import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,5 +9,5 @@ import lombok.Setter;
 @Setter
 public class CreateMainGoalRequest {
     private String mainGoalName;
-    private ArrayList<String> subGoalName;
+    private List<CreateSubGoalRequest> subGoals;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/CreateMainGoalResponse.java
@@ -1,0 +1,11 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateMainGoalResponse {
+    private Long mainGoalId;
+    private String mainGoalName;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
@@ -8,6 +8,5 @@ import lombok.Getter;
 public class CreateSubGoalRequest {
 
     private String name;
-    private String color;
     private List<CreateDailyActionRequest> dailyActions;
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 @Getter
 public class CreateSubGoalRequest {
 
-    private String subGoalName;
+    private String name;
+    private String color;
     private List<CreateDailyActionRequest> dailyActions;
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import com.org.candoit.domain.dailyaction.dto.CreateDailyActionRequest;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CreateSubGoalRequest {
+
+    private String subGoalName;
+    private List<CreateDailyActionRequest> dailyActions;
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #30 

## 👩🏻‍💻 구현 내용
### Problem
- 기존의 메인골을 사용해 새로운 메인골을 생성할 때, 기존 메인골-서브골- 데일리 액션이 함께 생성되어야 함.
- 그러나, 데일리 액션 생성 로직이 누락되어있음
- 메인골 생성 응답에서 생성한 데이터를 모두 반환했으나, 실제 프론트가 사용하는 데이터와 상이함.

### Approach
**① 메인골 생성 요청 dto 구조 수정**
- 메인골 생성 요청 dto를 다음과 같이 계층적으로 구성하여 한 번의 요청으로 메인골, 서브골, 데일리 액션을 모두 생성할 수 있도록 수정.
  - `CreateMainGoalRequest`: 메인골 정보
  - `CreateSubGoalRequest`: 서브골 정보
  - `CreateDailyActionRequest`: 데일리 액션 정보

**② 메인골 생성 응답 dto 수정**
- 생성한 **메인골의 이름과 id를 반환**하여 프론트 측에 생성되었음을 알릴 수 있도록 응답 데이터를 간략화

### Result
- 메인골을 생성하고, 서브골, 데일리 액션을 벌크 연산을 사용해 생성
- 조건문을 통해 `List<CreateSubGoalRequest>`가 존재하는 경우인지 판단
![image](https://github.com/user-attachments/assets/9c88e4f3-e96d-4ff8-941a-82f0c7228964)