### PR TITLE
feature: 사용자의 전체 만다라트 목록 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
@@ -1,0 +1,26 @@
+package com.org.candoit.domain.mandalart.controller;
+
+import com.org.candoit.domain.mandalart.dto.DetailMandalartResponse;
+import com.org.candoit.domain.mandalart.service.MandalartService;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.annotation.LoginMember;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/mandalart")
+public class MandalartController {
+
+    private final MandalartService mandalartService;
+
+    @GetMapping
+    public ResponseEntity<DetailMandalartResponse> getMandalart(@Parameter(hidden = true) @LoginMember Member loginMember) {
+        DetailMandalartResponse result = mandalartService.getMandalart(loginMember);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/dto/DetailDailyActionResponse.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/dto/DetailDailyActionResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.mandalart.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DetailDailyActionResponse {
+    private String title;
+    private String content;
+    private Integer targetNum;
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/dto/DetailMainGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/dto/DetailMainGoalResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.mandalart.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DetailMainGoalResponse {
+    private String name;
+    private List<DetailSubGoalResponse> subGoals;
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/dto/DetailMandalartResponse.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/dto/DetailMandalartResponse.java
@@ -1,0 +1,11 @@
+package com.org.candoit.domain.mandalart.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class DetailMandalartResponse {
+    List<DetailMainGoalResponse> mainGoals;
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/dto/DetailSubGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/dto/DetailSubGoalResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.mandalart.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DetailSubGoalResponse {
+    private String name;
+    private List<DetailDailyActionResponse> dailyActions;
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
@@ -1,0 +1,64 @@
+package com.org.candoit.domain.mandalart.service;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.mandalart.dto.DetailDailyActionResponse;
+import com.org.candoit.domain.mandalart.dto.DetailMainGoalResponse;
+import com.org.candoit.domain.mandalart.dto.DetailMandalartResponse;
+import com.org.candoit.domain.mandalart.dto.DetailSubGoalResponse;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MandalartService {
+
+    private final SubGoalCustomRepository subGoalRepository;
+
+    public DetailMandalartResponse getMandalart(Member loginMember) {
+
+        List<SubGoal> subGoals = subGoalRepository.findByMemberId(loginMember.getMemberId());
+        List<DetailMainGoalResponse> detailMainGoalResponses = new ArrayList<>();
+
+        Map<Long, List<SubGoal>> byMainGoalId = subGoals.stream()
+            .collect(Collectors.groupingBy(subGoal -> subGoal.getMainGoal().getMainGoalId()));
+
+        byMainGoalId.forEach((mainGoalId, subGoalList)->{
+            List<DetailSubGoalResponse> detailSubGoalResponses = new ArrayList<>();
+           subGoalList.forEach(subGoal -> {
+             List<DailyAction> dailyActions = subGoal.getDailyActions();
+             List<DetailDailyActionResponse> detailDailyActionResponses = IntStream.range(0, dailyActions.size())
+                 .boxed()
+                 .map(i -> {
+                     return DetailDailyActionResponse.builder()
+                         .title(dailyActions.get(i).getDailyActionTitle())
+                         .content(dailyActions.get(i).getContent())
+                         .targetNum(dailyActions.get(i).getTargetNum())
+                         .build();
+                 }).collect(Collectors.toList());
+
+             DetailSubGoalResponse detailSubGoalResponse = DetailSubGoalResponse.builder()
+                 .name(subGoal.getSubGoalName())
+                 .dailyActions(detailDailyActionResponses)
+                 .build();
+
+             detailSubGoalResponses.add(detailSubGoalResponse);
+           });
+           detailMainGoalResponses.add(DetailMainGoalResponse.builder()
+               .name(subGoalList.get(0).getMainGoal().getMainGoalName())
+               .subGoals(detailSubGoalResponses)
+               .build());
+        });
+
+        return DetailMandalartResponse.builder()
+            .mainGoals(detailMainGoalResponses)
+            .build();
+    }
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
@@ -1,7 +1,9 @@
 package com.org.candoit.domain.subgoal.entity;
 
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.global.BaseTimeEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -11,6 +13,9 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,4 +43,7 @@ public class SubGoal extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_goal_id")
     private MainGoal mainGoal;
+
+    @OneToMany(mappedBy = "subGoal", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<DailyAction> dailyActions = new ArrayList<>();
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
@@ -1,0 +1,9 @@
+package com.org.candoit.domain.subgoal.repository;
+
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import java.util.List;
+
+public interface SubGoalCustomRepository {
+
+    List<SubGoal> findByMemberId(Long memberId);
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.org.candoit.domain.subgoal.repository;
+
+import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
+import static com.org.candoit.domain.subgoal.entity.QSubGoal.subGoal;
+
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SubGoalCustomRepositoryImpl implements SubGoalCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<SubGoal> findByMemberId(Long memberId) {
+        return jpaQueryFactory.select(subGoal)
+            .from(subGoal)
+            .innerJoin(mainGoal)
+            .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
+            .where(mainGoal.member.memberId.eq(memberId))
+            .fetch();
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #33 

## 👩🏻‍💻 구현 내용
### Problem
- `가져오기` 기능을 위한 전체 만다라트 목록 조회 api 필요

### Approach
- `Collectors.groupingBy`를 통해 `MainGoal` 기준으로 1차 분류하고, 각각 서브골과 데일리 액션을 `forEach`, `map`을 사용해 DTO로 변환

### Result
![image (17)](https://github.com/user-attachments/assets/51b162a3-e69b-4660-a2b3-700e8b905528)