### PR TITLE
feature: 메인골 프리뷰 리스트 조회

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -3,21 +3,26 @@ package com.org.candoit.domain.maingoal.controller;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.PreviewMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
 import com.org.candoit.domain.maingoal.service.MainGoalService;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -26,6 +31,21 @@ import org.springframework.web.bind.annotation.RestController;
 public class MainGoalController {
 
     private final MainGoalService mainGoalService;
+
+    @GetMapping
+    public ResponseEntity<List<PreviewMainGoalResponse>> getMainGoals(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @RequestParam(defaultValue = "all") String state
+    ) {
+        List<PreviewMainGoalResponse> result = mainGoalService.getPreviewList(member, checkFiltering(state));
+        return ResponseEntity.ok(result);
+    }
+
+    private MainGoalStatus checkFiltering(String state) {
+        if(state.equalsIgnoreCase("all")) return null;
+        return MainGoalStatus.valueOf(state.toUpperCase());
+    }
+
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateMainGoalResponse>> createMainGoal(

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/PreviewMainGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/PreviewMainGoalResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PreviewMainGoalResponse {
+
+    private Long mainGoalId;
+    private String mainGoalName;
+    private MainGoalStatus mainGoalStatus;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoalStatus.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoalStatus.java
@@ -1,10 +1,16 @@
 package com.org.candoit.domain.maingoal.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 
 @Getter
 public enum MainGoalStatus {
     ACTIVITY,
     ATTAINMENT,
-    PAUSE
+    PAUSE;
+
+    @JsonCreator
+    public static MainGoalStatus from(String input) {
+        return MainGoalStatus.valueOf(input.toUpperCase());
+    }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
@@ -1,10 +1,13 @@
 package com.org.candoit.domain.maingoal.repository;
 
 import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import java.util.List;
 import java.util.Optional;
 
 public interface MainGoalCustomRepository {
 
     Optional<MainGoal> findByMainGoalIdAndMemberId(Long mainGoalId, Long memberId);
     Optional<MainGoal> findRepresentativeMainGoalByMemberId(Long memberId);
+    List<MainGoal> findByMemberIdAndStatus(Long memberId, MainGoalStatus status);
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
@@ -4,7 +4,10 @@ import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
 import static com.org.candoit.domain.member.entity.QMember.member;
 
 import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -31,7 +34,20 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             .innerJoin(member)
             .on(mainGoal.member.memberId.eq(memberId))
             .where(
-               (mainGoal.isRepresentative.eq(Boolean.TRUE)))
+                (mainGoal.isRepresentative.eq(Boolean.TRUE)))
             .fetchOne());
+    }
+
+    @Override
+    public List<MainGoal> findByMemberIdAndStatus(Long memberId, MainGoalStatus status) {
+        return jpaQueryFactory.select(mainGoal)
+            .from(mainGoal)
+            .where((mainGoal.member.memberId.eq(memberId)).and(
+                checkStatus(status))).fetch();
+    }
+
+    private BooleanExpression checkStatus(MainGoalStatus status) {
+        if(status == null) return null;
+        return mainGoal.mainGoalStatus.eq(status);
     }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -6,6 +6,7 @@ import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.PreviewMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
@@ -19,7 +20,6 @@ import com.org.candoit.domain.subgoal.entity.Color;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
 import com.org.candoit.global.response.CustomException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -148,5 +148,17 @@ public class MainGoalService {
                 .isStore(subGoal.getIsStore())
                 .build())
             .collect(Collectors.toList());
+    }
+
+    public List<PreviewMainGoalResponse> getPreviewList(Member member, MainGoalStatus state) {
+
+       return mainGoalCustomRepository.findByMemberIdAndStatus(member.getMemberId(), state)
+           .stream()
+           .map(mainGoal -> PreviewMainGoalResponse.builder()
+               .mainGoalId(mainGoal.getMainGoalId())
+               .mainGoalName(mainGoal.getMainGoalName())
+               .mainGoalStatus(mainGoal.getMainGoalStatus())
+               .build())
+           .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #35 

## 👩🏻‍💻 구현 내용
### Problem
- 메인골 리스트 조회 api 필요

### Approach
- `queryDsl`을 사용해 필터링 조건에 따라 데이터를 조회할 수 있도록 함.