### PR TITLE
fix: 메인골 리스트 조회 응답값 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -2,8 +2,8 @@ package com.org.candoit.domain.maingoal.controller;
 
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.MainGoalListResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
-import com.org.candoit.domain.maingoal.dto.PreviewMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
 import com.org.candoit.domain.maingoal.service.MainGoalService;
@@ -11,7 +11,6 @@ import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,19 +32,18 @@ public class MainGoalController {
     private final MainGoalService mainGoalService;
 
     @GetMapping
-    public ResponseEntity<List<PreviewMainGoalResponse>> getMainGoals(
+    public ResponseEntity<ApiResponse<MainGoalListResponse>> getMainGoals(
         @Parameter(hidden = true) @LoginMember Member member,
         @RequestParam(defaultValue = "all") String state
     ) {
-        List<PreviewMainGoalResponse> result = mainGoalService.getPreviewList(member, checkFiltering(state));
-        return ResponseEntity.ok(result);
+        MainGoalListResponse result = mainGoalService.getPreviewList(member, checkFiltering(state));
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     private MainGoalStatus checkFiltering(String state) {
         if(state.equalsIgnoreCase("all")) return null;
         return MainGoalStatus.valueOf(state.toUpperCase());
     }
-
 
     @PostMapping
     public ResponseEntity<ApiResponse<CreateMainGoalResponse>> createMainGoal(

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalListCompositionResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalListCompositionResponse.java
@@ -6,9 +6,10 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class PreviewMainGoalResponse {
+public class MainGoalListCompositionResponse {
 
-    private Long mainGoalId;
-    private String mainGoalName;
-    private MainGoalStatus mainGoalStatus;
+    private Long id;
+    private String name;
+    private MainGoalStatus status;
+    private Boolean isRep;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalListResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalListResponse.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class MainGoalListResponse {
+
+    private List<MainGoalListCompositionResponse> mainGoals;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -5,8 +5,9 @@ import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.MainGoalListCompositionResponse;
+import com.org.candoit.domain.maingoal.dto.MainGoalListResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
-import com.org.candoit.domain.maingoal.dto.PreviewMainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
@@ -150,15 +151,17 @@ public class MainGoalService {
             .collect(Collectors.toList());
     }
 
-    public List<PreviewMainGoalResponse> getPreviewList(Member member, MainGoalStatus state) {
+    public MainGoalListResponse getPreviewList(Member member, MainGoalStatus state) {
 
-       return mainGoalCustomRepository.findByMemberIdAndStatus(member.getMemberId(), state)
-           .stream()
-           .map(mainGoal -> PreviewMainGoalResponse.builder()
-               .mainGoalId(mainGoal.getMainGoalId())
-               .mainGoalName(mainGoal.getMainGoalName())
-               .mainGoalStatus(mainGoal.getMainGoalStatus())
-               .build())
-           .collect(Collectors.toList());
+        return MainGoalListResponse.builder()
+            .mainGoals(mainGoalCustomRepository.findByMemberIdAndStatus(member.getMemberId(), state)
+                .stream()
+                .map(mainGoal -> MainGoalListCompositionResponse.builder()
+                    .id(mainGoal.getMainGoalId())
+                    .name(mainGoal.getMainGoalName())
+                    .status(mainGoal.getMainGoalStatus())
+                    .isRep(mainGoal.getIsRepresentative())
+                    .build())
+                .collect(Collectors.toList())).build();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #39 

## 👩🏻‍💻 구현 내용
### Problem
- 메인골 리스트 조회 api에서 다음과 같은 문제점이 있었음.
  - 대표 여부에 대한 응답 미포함
  - `main_goal_` 접두사를 붙인 flat한 구조
  - 공통 응답 포맷을 사용하지 않았음.
  ```json
    [
      {
        "main_goal_id":1,
        "main_goal_name":"예제메인골1",
        "main_goal_status":"ACTIVITY"
      },
      {
        "main_goal_id":2,
        "main_goal_name":"예제메인골2",
        "main_goal_status":"ACTIVITY"
      }
    ]
   ```

### Approach
- 대표 여부에 대한 응답을 `is_rep`(key), `Boolean`(value)로 반환
- `main_goals` 키로 리스트를 감싸 구조화 ➡️ 데이터 의미 명확화 + 가독성 향상
- 공통 응답 포맷 적용
  ```json
  {
    "code": "200",
    "message": "success",
    "data": {
      "main_goals": [
        {
          "id": 1,
          "name": "string",
          "status": "ACTIVITY",
          "is_rep": true
        },
        {
          "id": 2,
          "name": "string1",
          "status": "ACTIVITY",
          "is_rep": false
        }
      ]
   }
  }
  ```


