### PR TITLE
chore: cd 방법 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,27 +2,51 @@ name: Deploy To EC2
 
 on:
   push:
-    branches:
-      - main
+  branches:
+    - main
 
 jobs:
-  Deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: SSH로  EC2에 접속
-        uses: appleboy/ssh-action@v1.0.3
-        env:
-          APPLICATION_PROPERTIES: ${{ secrets.APPLICATION_PROPERTIES }}
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          envs: APPLICATION_PROPERTIES
-          script: |
-            cd /home/ubuntu/candoit-server
-            rm -rf src/main/resources/application.yml
-            git pull origin main
-            echo "$APPLICATION_PROPERTIES" > src/main/resources/application.yml
-            ./gradlew clean build
-            sudo fuser -k -n tcp 8080 || true
-            nohup java -jar build/libs/*SNAPSHOT.jar > ./output.log 2>&1 &
+  deploy:
+  runs-on: ubuntu-latest
+  steps:
+    - name: Github Repository 파일 불러오기
+      uses: actions/checkout@v4
+    - name: JDK 17버전 설치
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+
+    - name: application.yml 파일 만들기
+      run: echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/application.yml
+
+    - name: 테스트 및 빌드하기
+      run: ./gradlew clean build
+
+    - name: 빌드된 파일 이름 변경하기
+      run: mv ./build/libs/*SNAPSHOT.jar ./project.jar
+
+    - name: SCP로 EC2에 빌드된 파일 전송하기
+      uses: appleboy/scp-action@v0.1.7
+      with:
+        host: ${{ secrets.EC2_HOST }}
+        username: ${{ secrets.EC2_USERNAME }}
+        key: ${{ secrets.EC2_PRIVATE_KEY }}
+        source: project.jar
+        target: /home/ubuntu/back-end/tobe
+
+    - name: SSH로 EC2에 접속하기
+      uses: appleboy/ssh-action@v1.0.3
+      with:
+      host: ${{ secrets.EC2_HOST }}
+      username: ${{ secrets.EC2_USERNAME }}
+      key: ${{ secrets.EC2_PRIVATE_KEY }}
+      script_stop: true
+      script: |
+        rm -rf /home/ubuntu/back-end/current
+        mkdir /home/ubuntu/back-end/current
+        mv /home/ubuntu/back-end/tobe/project.jar /home/ubuntu/back-end/current/project.jar
+        cd /home/ubuntu/back-end/current
+        sudo fuser -k -n tcp 8080 || true
+        nohup java -jar project.jar > ./output.log 2>&1 &
+        rm -rf /home/ubuntu/back-end/tobe


### PR DESCRIPTION
# 📌 이슈 번호
- #6 
## 👩🏻‍💻 구현 내용
### Problem
- 기존에는 EC2 인스턴스 내에서 빌드와 배포를 모두 수행하는 구조였음. ➜ **리소스 소모량 ⬆︎**

### Approach
- GitHub Actions에서 먼저 빌드하고, EC2에서 배포하는 구조로 역할을 분산시킴