### PR TITLE
chore: gradle 실행 권한 부여

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,9 @@ jobs:
           mkdir -p ./src/main/resources
           echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/application.yml
 
+      - name: Gradle 실행 권한 부여
+        run: chmod +x ./gradlew
+
       - name: 테스트 및 빌드하기
         run: ./gradlew clean build
 


### PR DESCRIPTION
## 📌 이슈 번호
- #6
## 👩🏻‍💻 구현 내용
### Problem
- gradle에 대한 권한이 없어 오류 발생함.
### Approach
- `chmod +x`를 사용해 권한 부여