### PR TITLE
fix: mariadb에서 mysql로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     // DB
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    implementation 'mysql:mysql-connector-java:8.0.33'
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"


### PR DESCRIPTION
## 📌 이슈 번호
- #6

## 👩🏻‍💻 구현 내용
### Problem
- AWS와 로컬 환경에서의 DB 툴이 다름.
  - AWS는 MySQL을 프리티어로 제공하고 있어 배포 환경에서는 MySQL을 채택
  - 로컬 환경에서는 기존에 사용하던 MariaDB가 설정되어 있음. 

### Approach
- build.gradle 파일 수정
   - MySQL로 DB 툴 변경