### PR TITLE
fix: corsConfig 수정

### DIFF
--- a/src/main/java/com/org/candoit/global/config/CorsConfig.java
+++ b/src/main/java/com/org/candoit/global/config/CorsConfig.java
@@ -13,13 +13,14 @@ public class CorsConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(List.of(
+        configuration.setAllowedOriginPatterns(List.of(
             "http://localhost:3000","http://localhost:8080",
             "https://handa-plan.com"
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600l);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 📌 이슈 번호
- #53

## 👩🏻‍💻 구현 내용
### Problem
- HTTPS 통신이 되지 않는 문제를 해결하기 위해 CORS 설정을 반복적으로 수정

### Approach
- EC2 보안 그룹에서 443 포트가 0.0.0.0/0으로 열려 있지 않았던 것이 원인이었으며, 해당 설정을 수정하여 정상적으로 HTTPS 통신이 가능해짐.
- 문제 해결 과정에서 다음과 같은 PR이 생성되었습니다:
  - #56
  - #57
  - #58
  - #59