### PR TITLE
fix: 로그인 응답 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
@@ -25,12 +25,11 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Object>> login(@RequestBody LoginRequest loginRequest) {
-        LoginResponse loginResponse = authService.login(loginRequest);
 
+        LoginResponse loginResponse = authService.login(loginRequest);
         return ResponseEntity.ok()
             .headers(loginResponse.getHttpHeaders())
-            .body(ApiResponse.successWithoutData());
-
+            .body(ApiResponse.success(loginResponse.getMemberInfo()));
     }
 
     @PostMapping("/logout")
@@ -38,6 +37,7 @@ public class AuthController {
         @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
         @Parameter(hidden = true) @CookieValue(name = "refresh-token") String refreshToken
     ) {
+
         LogoutResponse logoutResponse = authService.logout(accessToken, refreshToken);
         return ResponseEntity.ok().headers(logoutResponse.getHttpHeaders())
             .body(ApiResponse.successWithoutData());
@@ -47,6 +47,7 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Object>> reissue(
         @RequestHeader("Authorization") String accessToken,
         @Parameter(hidden = true) @CookieValue(name = "refresh-token") String refreshToken) {
+
         ReissueResponse reissueResponse = authService.reissue(accessToken, refreshToken);
         return ResponseEntity.ok().headers(reissueResponse.getHttpHeaders())
             .body(ApiResponse.successWithoutData());

--- a/src/main/java/com/org/candoit/domain/auth/dto/LoginResponse.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/LoginResponse.java
@@ -1,6 +1,7 @@
 package com.org.candoit.domain.auth.dto;
 
 
+import com.org.candoit.domain.member.dto.BasicMemberInfoResponse;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,5 @@ import org.springframework.http.HttpHeaders;
 public class LoginResponse {
 
     private HttpHeaders httpHeaders;
+    private BasicMemberInfoResponse memberInfo;
 }

--- a/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import com.org.candoit.domain.auth.dto.LoginResponse;
 import com.org.candoit.domain.auth.dto.LogoutResponse;
 import com.org.candoit.domain.auth.dto.NewTokenResponse;
 import com.org.candoit.domain.auth.dto.ReissueResponse;
+import com.org.candoit.domain.member.dto.BasicMemberInfoResponse;
+import com.org.candoit.global.security.basic.CustomUserDetails;
 import com.org.candoit.global.security.jwt.JwtService;
 import com.org.candoit.global.security.jwt.JwtUtil;
 import java.time.Duration;
@@ -45,8 +47,10 @@ public class AuthService {
         accessTokenSend2Client(headers, accessToken);
         refreshTokenSend2Client(headers, refreshToken, 7);
 
-        return new LoginResponse(headers);
+        return new LoginResponse(headers,
+            new BasicMemberInfoResponse((CustomUserDetails) authentication.getPrincipal()));
     }
+
     private void accessTokenSend2Client(HttpHeaders headers, String accessToken) {
         headers.set("Authorization", "Bearer " + accessToken);
     }

--- a/src/main/java/com/org/candoit/domain/member/dto/BasicMemberInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/BasicMemberInfoResponse.java
@@ -1,0 +1,37 @@
+package com.org.candoit.domain.member.dto;
+
+import com.org.candoit.domain.member.entity.MemberRole;
+import com.org.candoit.domain.member.entity.MemberStatus;
+import com.org.candoit.global.security.basic.CustomUserDetails;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+public class BasicMemberInfoResponse {
+
+    private Long memberId;
+
+    private String email;
+
+    private String nickname;
+
+    private String comment;
+
+    private String profilePath;
+
+    private MemberStatus memberStatus;
+
+    private MemberRole memberRole;
+
+    public BasicMemberInfoResponse(CustomUserDetails customUserDetails) {
+
+        this.memberId = customUserDetails.getMember().getMemberId();
+        this.email = customUserDetails.getMember().getEmail();
+        this.nickname = customUserDetails.getMember().getNickname();
+        this.comment = customUserDetails.getMember().getComment();
+        this.profilePath = customUserDetails.getMember().getProfilePath();
+        this.memberStatus = customUserDetails.getMember().getMemberStatus();
+        this.memberRole = customUserDetails.getMember().getMemberRole();
+    }
+}

--- a/src/main/java/com/org/candoit/global/config/RedisConfig.java
+++ b/src/main/java/com/org/candoit/global/config/RedisConfig.java
@@ -11,10 +11,10 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.redis.data.host}")
     private String host;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.redis.data.port}")
     private int port;
 
     @Bean


### PR DESCRIPTION
## 📌 이슈 번호
- #60 

## 👩🏻‍💻 구현 내용
### Problem
- 기존에는 로그인 요청에 대한 응답 바디에 아무런 데이터가 없어 프론트에서 로그인한 회원의 정보를 알 수 없었음.
- Springboot 3.2이상의 버전에서 `spring.redis.host`, `spring.redis.password`가 deprecated됨.
### Approach
- 프론트에서 로그인한 회원의 정보를 활용할 수 있도록 해당 정보를 바디에 담아 응답하도록 수정
- 각각 `spring.data.redis.host`, `spring.data.redis.password`로 변경