### PR TITLE
fix: 회원가입 예외 처리 추가

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/member/exception/MemberErrorCode.java
@@ -11,7 +11,9 @@ public enum MemberErrorCode implements ErrorCode {
 
     NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "00000", "사용자를 찾지 못했습니다."),
     NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "00001", "비밀번호가 일치하지 않습니다."),
-    WITHDRAWN_MEMBER(HttpStatus.BAD_REQUEST, "00002", "탈퇴한 사용자입니다.");
+    WITHDRAWN_MEMBER(HttpStatus.BAD_REQUEST, "00002", "탈퇴한 사용자입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "00003", "이미 존재하는 이메일 입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "00004", "이미 존재하는 닉네임 입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
@@ -8,4 +8,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
     Optional<Member> findByNickname(String nickname);
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -63,9 +63,10 @@ public class SecurityConfig {
                     "/swagger-ui/**",
                     "/v3/api-docs/**").permitAll()
                 // 로그인, 회원가입, 토큰 재발행
-                .requestMatchers("/api/auth/login", "/api/members/join", "/api/auth/reissue"
+                .requestMatchers("/api/auth/login", "/api/members/join", "/api/auth/reissue",
+                    "/api/members/check"
                     ).permitAll()
-                .requestMatchers("/api/members/check", "/api/auth/logout", "/api/main-goals").hasRole("USER")
+                .requestMatchers("/api/auth/logout", "/api/main-goals").hasRole("USER")
                 .anyRequest().authenticated()
             );
 

--- a/src/main/java/com/org/candoit/global/config/SwaggerConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SwaggerConfig.java
@@ -11,8 +11,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-    info = @Info(title = "한다라트 API 명세서", version = "1.0", description = "한다라트 API 명세서"),
-    servers = @Server(url = "https://api.handa-plan.com"))
+    info = @Info(title = "한다라트 API 명세서", version = "1.0", description = "한다라트 API 명세서")
+    //servers = @Server(url = "https://api.handa-plan.com")
+    )
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/com/org/candoit/global/config/SwaggerConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SwaggerConfig.java
@@ -11,8 +11,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @OpenAPIDefinition(
-    info = @Info(title = "한다라트 API 명세서", version = "1.0", description = "한다라트 API 명세서")
-    //servers = @Server(url = "https://api.handa-plan.com")
+    info = @Info(title = "한다라트 API 명세서", version = "1.0", description = "한다라트 API 명세서"),
+    servers = @Server(url = "https://api.handa-plan.com")
     )
 @Configuration
 public class SwaggerConfig {

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -28,7 +28,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final Set<String> excludeAllPaths = Set.of(
         "/swagger-ui/**", "/v3/api-docs/**",
-        "/api/auth/login/**", "/api/members/join/**", "/api/auth/reissue/**"
+        "/api/auth/login/**", "/api/members/join/**", "/api/auth/reissue/**",
+        "/api/members/check"
     );
 
     public JwtAuthorizationFilter(JwtUtil jwtUtil) {


### PR DESCRIPTION
## 📌 이슈 번호
- #60

## 👩🏻‍💻 구현 내용
### Problem
- 기존에는 회원가입 API 내에서는 해당 중복 검증을 수행하지 않았음. 
- 이메일 및 닉네임 중복 체크 api에서 `NullPointerException` 발생 가능성 고려

### Approach
- 회원가입 시에도 닉네임과 이메일 중복 여부를 검증하도록 로직 추가
- `type.equals("nickname")` ➜ `"nickname".equals(type)` 