### PR TITLE
fix: 프론트 로컬 경로의 포트 변경

### DIFF
--- a/src/main/java/com/org/candoit/global/config/CorsConfig.java
+++ b/src/main/java/com/org/candoit/global/config/CorsConfig.java
@@ -14,7 +14,7 @@ public class CorsConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOriginPatterns(List.of(
-            "http://localhost:3000","http://localhost:8080",
+            "http://localhost:5173","http://localhost:8080",
             "https://handa-plan.vercel.app", "https://api.handa-plan.com"
         ));
         configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));


### PR DESCRIPTION
## 📌 이슈 번호
- #65

## 👩🏻‍💻 구현 내용
### Problem
- CorsConfig에 작성한 포트 번호와 실제 프론트 팀원의 포트 번호가 다름.

### Approach
- 포트 번호 변경 **`3000 ➜ 5173`**

