### PR TITLE
fix: 만다라트 메인골 오버뷰 분리

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/dto/SimpleMainGoalInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/SimpleMainGoalInfoResponse.java
@@ -1,0 +1,13 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class SimpleMainGoalInfoResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
@@ -10,4 +10,5 @@ public interface MainGoalCustomRepository {
     Optional<MainGoal> findByMainGoalIdAndMemberId(Long mainGoalId, Long memberId);
     Optional<MainGoal> findRepresentativeMainGoalByMemberId(Long memberId);
     List<MainGoal> findByMemberIdAndStatus(Long memberId, MainGoalStatus status);
+    List<MainGoal> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.org.candoit.domain.maingoal.repository;
 
 import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
 import static com.org.candoit.domain.member.entity.QMember.member;
-
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -44,6 +43,14 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             .from(mainGoal)
             .where((mainGoal.member.memberId.eq(memberId)).and(
                 checkStatus(status))).fetch();
+    }
+
+    @Override
+    public List<MainGoal> findByMemberId(Long memberId) {
+        return jpaQueryFactory.select(mainGoal)
+            .from(mainGoal)
+            .where((mainGoal.member.memberId.eq(memberId)))
+            .fetch();
     }
 
     private BooleanExpression checkStatus(MainGoalStatus status) {

--- a/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
@@ -1,6 +1,6 @@
 package com.org.candoit.domain.mandalart.controller;
 
-import com.org.candoit.domain.mandalart.dto.DetailMandalartResponse;
+import com.org.candoit.domain.mandalart.dto.MainGoalOverviewResponse;
 import com.org.candoit.domain.mandalart.service.MandalartService;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.annotation.LoginMember;
@@ -18,9 +18,9 @@ public class MandalartController {
 
     private final MandalartService mandalartService;
 
-    @GetMapping
-    public ResponseEntity<DetailMandalartResponse> getMandalart(@Parameter(hidden = true) @LoginMember Member loginMember) {
-        DetailMandalartResponse result = mandalartService.getMandalart(loginMember);
+    @GetMapping("/main-goals")
+    public ResponseEntity<MainGoalOverviewResponse> getMandalart(@Parameter(hidden = true) @LoginMember Member loginMember) {
+        MainGoalOverviewResponse result = mandalartService.getMainGoalList(loginMember);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/org/candoit/domain/mandalart/dto/MainGoalOverviewResponse.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/dto/MainGoalOverviewResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.mandalart.dto;
+
+import com.org.candoit.domain.maingoal.dto.SimpleMainGoalInfoResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MainGoalOverviewResponse {
+    private List<SimpleMainGoalInfoResponse> mainGoals;
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
@@ -1,18 +1,12 @@
 package com.org.candoit.domain.mandalart.service;
 
-import com.org.candoit.domain.dailyaction.entity.DailyAction;
-import com.org.candoit.domain.mandalart.dto.DetailDailyActionResponse;
-import com.org.candoit.domain.mandalart.dto.DetailMainGoalResponse;
-import com.org.candoit.domain.mandalart.dto.DetailMandalartResponse;
-import com.org.candoit.domain.mandalart.dto.DetailSubGoalResponse;
+import com.org.candoit.domain.maingoal.dto.SimpleMainGoalInfoResponse;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
+import com.org.candoit.domain.mandalart.dto.MainGoalOverviewResponse;
 import com.org.candoit.domain.member.entity.Member;
-import com.org.candoit.domain.subgoal.entity.SubGoal;
-import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,45 +14,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class MandalartService {
 
-    private final SubGoalCustomRepository subGoalRepository;
+    private final MainGoalCustomRepository mainGoalRepository;
 
-    public DetailMandalartResponse getMandalart(Member loginMember) {
-
-        List<SubGoal> subGoals = subGoalRepository.findByMemberId(loginMember.getMemberId());
-        List<DetailMainGoalResponse> detailMainGoalResponses = new ArrayList<>();
-
-        Map<Long, List<SubGoal>> byMainGoalId = subGoals.stream()
-            .collect(Collectors.groupingBy(subGoal -> subGoal.getMainGoal().getMainGoalId()));
-
-        byMainGoalId.forEach((mainGoalId, subGoalList)->{
-            List<DetailSubGoalResponse> detailSubGoalResponses = new ArrayList<>();
-           subGoalList.forEach(subGoal -> {
-             List<DailyAction> dailyActions = subGoal.getDailyActions();
-             List<DetailDailyActionResponse> detailDailyActionResponses = IntStream.range(0, dailyActions.size())
-                 .boxed()
-                 .map(i -> {
-                     return DetailDailyActionResponse.builder()
-                         .title(dailyActions.get(i).getDailyActionTitle())
-                         .content(dailyActions.get(i).getContent())
-                         .targetNum(dailyActions.get(i).getTargetNum())
-                         .build();
-                 }).collect(Collectors.toList());
-
-             DetailSubGoalResponse detailSubGoalResponse = DetailSubGoalResponse.builder()
-                 .name(subGoal.getSubGoalName())
-                 .dailyActions(detailDailyActionResponses)
-                 .build();
-
-             detailSubGoalResponses.add(detailSubGoalResponse);
-           });
-           detailMainGoalResponses.add(DetailMainGoalResponse.builder()
-               .name(subGoalList.get(0).getMainGoal().getMainGoalName())
-               .subGoals(detailSubGoalResponses)
-               .build());
+    public MainGoalOverviewResponse getMainGoalList(Member loginMember) {
+        List<MainGoal> mainGoals = mainGoalRepository.findByMemberId(loginMember.getMemberId());
+        List<SimpleMainGoalInfoResponse> simpleMainGoalInfo = new ArrayList<>();
+        mainGoals.forEach(mainGoal -> {
+            simpleMainGoalInfo.add(new SimpleMainGoalInfoResponse(mainGoal.getMainGoalId(),
+                mainGoal.getMainGoalName()));
         });
-
-        return DetailMandalartResponse.builder()
-            .mainGoals(detailMainGoalResponses)
-            .build();
+        return new MainGoalOverviewResponse(simpleMainGoalInfo);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #68

## 👩🏻‍💻 구현 내용
### Problem
- 기존 만다라트 조회 api는 사용자의 메인골, 서브골, 데일리 액션의 모든 데이터를 한 번에 응답하고 있었음.
- 이 경우, 데이터가 많아질 수록 응답량이 커져 성능 저하의 우려가 있음.

### Approach
- **데이터를 나누어 조회하는 방식으로 리팩터링을 진행 중**
- 이번에는 **사용자의 메인골 리스트만 단독으로 조회하는 API**를 분리해 구현함.

_이후 단계에서 선택된 메인골, 서브골, 데일리 액션 등의 상세 데이터도 별도 API로 분리할 예정입니다._