### PR TITLE
fix: cors설정파일에 exposedHeader추가

### DIFF
--- a/src/main/java/com/org/candoit/global/config/CorsConfig.java
+++ b/src/main/java/com/org/candoit/global/config/CorsConfig.java
@@ -21,6 +21,7 @@ public class CorsConfig {
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600l);
+        configuration.setExposedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 📌 이슈 번호
- #71
## 👩🏻‍💻 구현 내용
### Problem
- 프론트에서 js가 액세스 토큰을 읽어올 수 없음

### Approach
- js가 `Authorization` 헤더를 읽을 수 있도록 `exposedHeader`에 추가함.