### PR TITLE
feature: 만다라트 서브골 리스트 오버뷰 조회 분리

### DIFF
--- a/src/main/java/com/org/candoit/domain/maingoal/dto/SimpleMainGoalInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/SimpleMainGoalInfoResponse.java
@@ -3,10 +3,12 @@ package com.org.candoit.domain.maingoal.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class SimpleMainGoalInfoResponse {
     private Long id;
     private String name;

--- a/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
@@ -1,6 +1,7 @@
 package com.org.candoit.domain.mandalart.controller;
 
 import com.org.candoit.domain.mandalart.dto.MainGoalOverviewResponse;
+import com.org.candoit.domain.mandalart.dto.SubGoalOverviewResponse;
 import com.org.candoit.domain.mandalart.service.MandalartService;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.annotation.LoginMember;
@@ -8,6 +9,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,8 +21,16 @@ public class MandalartController {
     private final MandalartService mandalartService;
 
     @GetMapping("/main-goals")
-    public ResponseEntity<MainGoalOverviewResponse> getMandalart(@Parameter(hidden = true) @LoginMember Member loginMember) {
+    public ResponseEntity<MainGoalOverviewResponse> getMandalart(
+        @Parameter(hidden = true) @LoginMember Member loginMember) {
         MainGoalOverviewResponse result = mandalartService.getMainGoalList(loginMember);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/main-goals/{mainGoalId}")
+    public ResponseEntity<SubGoalOverviewResponse> getSubGoalList(
+        @Parameter(hidden = true) @LoginMember Member loginMember, @PathVariable Long mainGoalId) {
+        SubGoalOverviewResponse result = mandalartService.getSubGoalList(loginMember, mainGoalId);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/org/candoit/domain/mandalart/dto/SubGoalOverviewResponse.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/dto/SubGoalOverviewResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.mandalart.dto;
+
+import com.org.candoit.domain.maingoal.dto.SimpleMainGoalInfoResponse;
+import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SubGoalOverviewResponse {
+    private SimpleMainGoalInfoResponse mainGoal;
+    private List<SimpleSubGoalInfoResponse> subGoals;
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
@@ -2,9 +2,15 @@ package com.org.candoit.domain.mandalart.service;
 
 import com.org.candoit.domain.maingoal.dto.SimpleMainGoalInfoResponse;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
 import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
 import com.org.candoit.domain.mandalart.dto.MainGoalOverviewResponse;
+import com.org.candoit.domain.mandalart.dto.SubGoalOverviewResponse;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import com.org.candoit.global.response.CustomException;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -15,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class MandalartService {
 
     private final MainGoalCustomRepository mainGoalRepository;
+    private final SubGoalCustomRepository subGoalRepository;
 
     public MainGoalOverviewResponse getMainGoalList(Member loginMember) {
         List<MainGoal> mainGoals = mainGoalRepository.findByMemberId(loginMember.getMemberId());
@@ -24,5 +31,32 @@ public class MandalartService {
                 mainGoal.getMainGoalName()));
         });
         return new MainGoalOverviewResponse(simpleMainGoalInfo);
+    }
+
+    public SubGoalOverviewResponse getSubGoalList(Member loginMember, Long mainGoalId) {
+        List<SubGoal> subGoals = subGoalRepository.findByMemberIdAndMainGoalId(
+            loginMember.getMemberId(), mainGoalId);
+
+        if (subGoals.isEmpty()) {
+            MainGoal mainGoal = mainGoalRepository.findByMainGoalIdAndMemberId(
+                    loginMember.getMemberId(), mainGoalId)
+                .orElseThrow(() -> new CustomException(MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
+            SimpleMainGoalInfoResponse simpleMainGoalInfoResponse = new SimpleMainGoalInfoResponse(
+                mainGoal.getMainGoalId(), mainGoal.getMainGoalName());
+            return new SubGoalOverviewResponse(simpleMainGoalInfoResponse, List.of());
+        } else {
+            List<SimpleSubGoalInfoResponse> simpleSubGoalInfo = new ArrayList<>();
+            subGoals.forEach(subGoal -> {
+                simpleSubGoalInfo.add(
+                    new SimpleSubGoalInfoResponse(subGoal.getSubGoalId(),
+                        subGoal.getSubGoalName()));
+            });
+
+            SimpleMainGoalInfoResponse mainGoalInfo = new SimpleMainGoalInfoResponse(
+                subGoals.get(0).getMainGoal().getMainGoalId(),
+                subGoals.get(0).getMainGoal().getMainGoalName());
+
+            return new SubGoalOverviewResponse(mainGoalInfo, simpleSubGoalInfo);
+        }
     }
 }

--- a/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
@@ -39,7 +39,7 @@ public class MandalartService {
 
         if (subGoals.isEmpty()) {
             MainGoal mainGoal = mainGoalRepository.findByMainGoalIdAndMemberId(
-                    loginMember.getMemberId(), mainGoalId)
+                    mainGoalId, loginMember.getMemberId())
                 .orElseThrow(() -> new CustomException(MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
             SimpleMainGoalInfoResponse simpleMainGoalInfoResponse = new SimpleMainGoalInfoResponse(
                 mainGoal.getMainGoalId(), mainGoal.getMainGoalName());

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/SimpleSubGoalInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/SimpleSubGoalInfoResponse.java
@@ -1,0 +1,11 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleSubGoalInfoResponse {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface SubGoalCustomRepository {
 
     List<SubGoal> findByMemberId(Long memberId);
+    List<SubGoal> findByMemberIdAndMainGoalId(Long memberId, Long mainGoalId);
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
@@ -19,9 +19,21 @@ public class SubGoalCustomRepositoryImpl implements SubGoalCustomRepository {
     public List<SubGoal> findByMemberId(Long memberId) {
         return jpaQueryFactory.select(subGoal)
             .from(subGoal)
-            .innerJoin(mainGoal)
+            .innerJoin(subGoal.mainGoal, mainGoal)
             .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
             .where(mainGoal.member.memberId.eq(memberId))
+            .fetch();
+    }
+
+    @Override
+    public List<SubGoal> findByMemberIdAndMainGoalId(Long memberId, Long mainGoalId) {
+        return jpaQueryFactory.select(subGoal)
+            .from(subGoal)
+            .innerJoin(mainGoal)
+            .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
+            .where(mainGoal.member.memberId.eq(memberId).and(
+                subGoal.mainGoal.mainGoalId.eq(mainGoalId)
+            ))
             .fetch();
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
@@ -29,7 +29,7 @@ public class SubGoalCustomRepositoryImpl implements SubGoalCustomRepository {
     public List<SubGoal> findByMemberIdAndMainGoalId(Long memberId, Long mainGoalId) {
         return jpaQueryFactory.select(subGoal)
             .from(subGoal)
-            .innerJoin(mainGoal)
+            .innerJoin(subGoal.mainGoal, mainGoal)
             .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
             .where(mainGoal.member.memberId.eq(memberId).and(
                 subGoal.mainGoal.mainGoalId.eq(mainGoalId)


### PR DESCRIPTION
## 📌 이슈 번호
- #68

## 👩🏻‍💻 구현 내용
### Problem
- 기존 만다라트 조회 api는 사용자의 메인골, 서브골, 데일리 액션의 모든 데이터를 한 번에 응답하고 있었음.
- 이 경우, 데이터가 많아질 수록 응답량이 커져 성능 저하의 우려가 있음.

### Approach
- **데이터를 나누어 조회하는 방식으로 리팩터링을 진행 중**
- 사용자가 **가져오고자 하는 메인골 클릭 시, 해당 메인골에 대한 서브골을 응답**하도록 구현함.