### PR TITLE
feature: 사용자가 선택한 서브골의 데일리액션 조회

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/DailyActionOverviewResponse.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/DailyActionOverviewResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.dailyaction.dto;
+
+import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class DailyActionOverviewResponse {
+
+    private SimpleSubGoalInfoResponse subGoal;
+    private List<SimpleDailyActionInfoResponse> dailyActions;
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/SimpleDailyActionInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/SimpleDailyActionInfoResponse.java
@@ -1,0 +1,15 @@
+package com.org.candoit.domain.dailyaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SimpleDailyActionInfoResponse {
+
+    private Long id;
+    private String title;
+    private String content;
+    private Integer targetNum;
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
@@ -1,0 +1,9 @@
+package com.org.candoit.domain.dailyaction.repository;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import java.util.List;
+
+public interface DailyActionCustomRepository {
+
+    List<DailyAction> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId);
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.org.candoit.domain.dailyaction.repository;
+
+import static com.org.candoit.domain.dailyaction.entity.QDailyAction.dailyAction;
+import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
+import static com.org.candoit.domain.subgoal.entity.QSubGoal.subGoal;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyActionCustomRepositoryImpl implements DailyActionCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<DailyAction> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId) {
+        return jpaQueryFactory.select(dailyAction)
+            .from(dailyAction)
+            .innerJoin(dailyAction.subGoal, subGoal)
+            .innerJoin(subGoal.mainGoal, mainGoal)
+            .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
+            .where(subGoal.subGoalId.eq(subGoalId).and(mainGoal.member.memberId.eq(memberId)
+            ))
+            .fetch();
+    }
+}

--- a/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/controller/MandalartController.java
@@ -1,5 +1,6 @@
 package com.org.candoit.domain.mandalart.controller;
 
+import com.org.candoit.domain.dailyaction.dto.DailyActionOverviewResponse;
 import com.org.candoit.domain.mandalart.dto.MainGoalOverviewResponse;
 import com.org.candoit.domain.mandalart.dto.SubGoalOverviewResponse;
 import com.org.candoit.domain.mandalart.service.MandalartService;
@@ -31,6 +32,13 @@ public class MandalartController {
     public ResponseEntity<SubGoalOverviewResponse> getSubGoalList(
         @Parameter(hidden = true) @LoginMember Member loginMember, @PathVariable Long mainGoalId) {
         SubGoalOverviewResponse result = mandalartService.getSubGoalList(loginMember, mainGoalId);
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/sub-goals/{subGoalId}")
+    public ResponseEntity<DailyActionOverviewResponse> getDailyActionList(
+        @Parameter(hidden = true) @LoginMember Member loginMember, @PathVariable Long subGoalId) {
+        DailyActionOverviewResponse result = mandalartService.getDailyActionList(loginMember, subGoalId);
         return ResponseEntity.ok(result);
     }
 }

--- a/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
+++ b/src/main/java/com/org/candoit/domain/mandalart/service/MandalartService.java
@@ -1,5 +1,9 @@
 package com.org.candoit.domain.mandalart.service;
 
+import com.org.candoit.domain.dailyaction.dto.DailyActionOverviewResponse;
+import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository;
 import com.org.candoit.domain.maingoal.dto.SimpleMainGoalInfoResponse;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
@@ -9,6 +13,7 @@ import com.org.candoit.domain.mandalart.dto.SubGoalOverviewResponse;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.exception.SubGoalErrorCode;
 import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import com.org.candoit.global.response.CustomException;
 import java.util.ArrayList;
@@ -22,6 +27,7 @@ public class MandalartService {
 
     private final MainGoalCustomRepository mainGoalRepository;
     private final SubGoalCustomRepository subGoalRepository;
+    private final DailyActionCustomRepository dailyActionCustomRepository;
 
     public MainGoalOverviewResponse getMainGoalList(Member loginMember) {
         List<MainGoal> mainGoals = mainGoalRepository.findByMemberId(loginMember.getMemberId());
@@ -57,6 +63,34 @@ public class MandalartService {
                 subGoals.get(0).getMainGoal().getMainGoalName());
 
             return new SubGoalOverviewResponse(mainGoalInfo, simpleSubGoalInfo);
+        }
+    }
+
+    public DailyActionOverviewResponse getDailyActionList(Member loginMember, Long subGoalId) {
+        List<DailyAction> dailyActions = dailyActionCustomRepository.findByMemberIdAndSubGoalId(
+            loginMember.getMemberId(), subGoalId);
+
+        if (dailyActions.isEmpty()) {
+            SubGoal subGoal = subGoalRepository.findByMemberIdAndSubGoalId(subGoalId,
+                loginMember.getMemberId()).orElseThrow(()->new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+            SimpleSubGoalInfoResponse simpleSubGoalInfoResponse = new SimpleSubGoalInfoResponse(
+                subGoal.getSubGoalId(), subGoal.getSubGoalName());
+            return new DailyActionOverviewResponse(simpleSubGoalInfoResponse, List.of());
+        } else {
+            List<SimpleDailyActionInfoResponse> simpleDailyActionInfo = new ArrayList<>();
+            dailyActions.forEach(dailyAction -> {
+                simpleDailyActionInfo.add(SimpleDailyActionInfoResponse.builder()
+                    .id(dailyAction.getDailyActionId())
+                    .title(dailyAction.getDailyActionTitle())
+                    .content(dailyAction.getContent())
+                    .targetNum(dailyAction.getTargetNum())
+                    .build());
+            });
+
+            SimpleSubGoalInfoResponse subGoalInfo = new SimpleSubGoalInfoResponse(
+                dailyActions.get(0).getSubGoal().getSubGoalId(),
+                dailyActions.get(0).getSubGoal().getSubGoalName());
+            return new DailyActionOverviewResponse(subGoalInfo, simpleDailyActionInfo);
         }
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/SimpleSubGoalInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/SimpleSubGoalInfoResponse.java
@@ -2,9 +2,11 @@ package com.org.candoit.domain.subgoal.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class SimpleSubGoalInfoResponse {
     private Long id;
     private String name;

--- a/src/main/java/com/org/candoit/domain/subgoal/exception/SubGoalErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/exception/SubGoalErrorCode.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.subgoal.exception;
+
+import com.org.candoit.global.response.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SubGoalErrorCode implements ErrorCode {
+    NOT_FOUND_SUB_GOAL(HttpStatus.NOT_FOUND, "80000", "일치하는 서브 골을 찾지 못했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
@@ -2,9 +2,11 @@ package com.org.candoit.domain.subgoal.repository;
 
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import java.util.List;
+import java.util.Optional;
 
 public interface SubGoalCustomRepository {
 
     List<SubGoal> findByMemberId(Long memberId);
     List<SubGoal> findByMemberIdAndMainGoalId(Long memberId, Long mainGoalId);
+    Optional<SubGoal> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId);
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import static com.org.candoit.domain.subgoal.entity.QSubGoal.subGoal;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -35,5 +36,16 @@ public class SubGoalCustomRepositoryImpl implements SubGoalCustomRepository {
                 subGoal.mainGoal.mainGoalId.eq(mainGoalId)
             ))
             .fetch();
+    }
+
+    @Override
+    public Optional<SubGoal> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId) {
+        return Optional.ofNullable(jpaQueryFactory.select(subGoal)
+            .from(subGoal)
+            .innerJoin(subGoal.mainGoal, mainGoal)
+            .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
+            .where(subGoal.subGoalId.eq(subGoalId).and(mainGoal.member.memberId.eq(memberId)
+            ))
+            .fetchOne());
     }
 }

--- a/src/main/java/com/org/candoit/global/config/CorsConfig.java
+++ b/src/main/java/com/org/candoit/global/config/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig {
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600l);
-        configuration.setExposedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+        configuration.setExposedHeaders(List.of("Authorization"));
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", configuration);


### PR DESCRIPTION
## 📌 이슈 번호
- #68 

### Problem
- 사용자가 메인골/서브골/데일리 액션을 생성할 때, 사용되는 
`가져오기` 기능에서 서브골에 속한 데일리 액션을 조회하는 기능이 필요함.
- 또한, `CorsConfig`의 `setExposedHeaders` 설정에 불필요한 헤더가 포함되어 있었음.

### Approach
- `@PathVariable`로 `subGoalId`를 받아 해당 서브골의 데일리 액션 목록을 DB에서 조회하도록 구현.
- 조회 결과가 없으면 `List.of()`를 반환하여 빈 배열 응답.
- 조회 결과가 있으면 데일리 액션 엔티티를 응답 DTO로 변환하여 반환.
- `CorsConfig`에서 불필요하게 포함된 헤더(`Cache-Control`, `Content-Type`) 제거.

### Result
- 서브골 단위 데일리 액션 조회 기능이 정상 동작.
- CORS 설정에서 불필요한 코드 제거

### Learn
- `Cache-Control`, `Content-Type`은 기본적으로 노출되는 헤더이므로 `setExposedHeaders`에 명시할 필요가 없음.
