### PR TITLE
feature: 상세 마이라트 조회

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
@@ -1,11 +1,17 @@
 package com.org.candoit.domain.dailyaction.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 @Getter
 public class CreateDailyActionRequest {
 
+    @NotNull
     private String title;
+    @NotNull
     private String content;
+    @NotNull @Min(1) @Max(7)
     private Integer targetNum;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/controller/MainGoalController.java
@@ -2,6 +2,7 @@ package com.org.candoit.domain.maingoal.controller;
 
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalRequest;
 import com.org.candoit.domain.maingoal.dto.CreateMainGoalResponse;
+import com.org.candoit.domain.maingoal.dto.MainGoalDetailsResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalListResponse;
 import com.org.candoit.domain.maingoal.dto.MainGoalResponse;
 import com.org.candoit.domain.maingoal.dto.UpdateMainGoalRequest;
@@ -86,5 +87,14 @@ public class MainGoalController {
         @PathVariable Long mainGoalId, @Valid @RequestBody UpdateMainGoalRequest updateMainGoalRequest) {
         MainGoalResponse mainGoalResponse = mainGoalService.updateMainGoal(member, mainGoalId, updateMainGoalRequest);
         return ResponseEntity.ok(ApiResponse.success(mainGoalResponse));
+    }
+
+    @GetMapping("{mainGoalId}")
+    public ResponseEntity<ApiResponse<MainGoalDetailsResponse>> getMainGoalDetail(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @PathVariable Long mainGoalId) {
+
+        MainGoalDetailsResponse result = mainGoalService.getMainGoalDetails(member, mainGoalId);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalDetailsResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalDetailsResponse.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import com.org.candoit.domain.subgoal.dto.SubGoalPreviewResponse;
+import com.org.candoit.domain.subprogress.dto.SubProgressOverviewResponse;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MainGoalDetailsResponse {
+
+    private SimpleMainGoalWithStatusResponse mainGoal;
+    private List<SubGoalPreviewResponse> subGoals;
+    private SubProgressOverviewResponse progress;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/SimpleMainGoalWithStatusResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/SimpleMainGoalWithStatusResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SimpleMainGoalWithStatusResponse {
+
+    private Long id;
+    private String name;
+    private MainGoalStatus status;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/SubGoalPreviewResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/SubGoalPreviewResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubGoalPreviewResponse {
+
+    private Long id;
+    private String name;
+    private String color;
+    private Boolean attainment;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepository.java
@@ -9,4 +9,5 @@ public interface SubGoalCustomRepository {
     List<SubGoal> findByMemberId(Long memberId);
     List<SubGoal> findByMemberIdAndMainGoalId(Long memberId, Long mainGoalId);
     Optional<SubGoal> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId);
+    List<SubGoal> findByMainGoalId(Long mainGoalId);
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/repository/SubGoalCustomRepositoryImpl.java
@@ -48,4 +48,11 @@ public class SubGoalCustomRepositoryImpl implements SubGoalCustomRepository {
             ))
             .fetchOne());
     }
+
+    @Override
+    public List<SubGoal> findByMainGoalId(Long mainGoalId) {
+        return jpaQueryFactory.selectFrom(subGoal)
+            .where(subGoal.mainGoal.mainGoalId.eq(mainGoalId))
+            .fetch();
+    }
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/DetailSubProgressResponse.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/DetailSubProgressResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.subprogress.dto;
+
+import com.org.candoit.domain.subgoal.entity.Color;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class DetailSubProgressResponse {
+
+    private String subGoalName;
+    private String color;
+    private Integer rate;
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/SubProgressOverviewResponse.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/SubProgressOverviewResponse.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.subprogress.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubProgressOverviewResponse {
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Integer weekOfMonth;
+    private List<DetailSubProgressResponse> subProgress;
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressRepository.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressRepository.java
@@ -4,5 +4,5 @@ import com.org.candoit.domain.subprogress.entity.SubProgress;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SubProgressRepository extends JpaRepository<SubProgress, Long> {
-
+    public SubProgress findBySubGoal_SubGoalId(Long subGoalId);
 }

--- a/src/main/java/com/org/candoit/global/util/DateTimeUtil.java
+++ b/src/main/java/com/org/candoit/global/util/DateTimeUtil.java
@@ -1,0 +1,15 @@
+package com.org.candoit.global.util;
+
+import java.time.LocalDate;
+
+public class DateTimeUtil {
+
+    public static int getWeekOfMonth(LocalDate date){
+        LocalDate firstDayOfMonth = date.withDayOfMonth(1);
+        int dayOfWeekOfFirst = firstDayOfMonth.getDayOfWeek().getValue();
+
+        int day = date.getDayOfWeek().getValue();
+
+        return (day + dayOfWeekOfFirst - 2) / 7 + 1;
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #38

## 👩🏻‍💻 구현 내용

### Problem
- `DailyActionRequest` 필드에 대한 검증 부재로 잘못된 입력을 허용할 수 있음.
- 상세 메인골 조회 api 필요

### Approach
- DTO에 `@ NotNull`, `@ Min`, `@ Max` 추가
- `@ PathVariable`을 통해 얻은 MainGoalId를 바탕으로 MainGoal을 DB에서 가져옴.
	- MainGoal이 존재하지 않는 경우, `404 Not Found MainGoal` 반환
- MainGoal을 `SimpleMainGoalWithStatusResponse`로 변환함.
- `mainGoalId`로 `List<SubGoal>` 조회 후 SubGoalPreviewResponse로 변환함.
-  조회 기준일이 속한 **주간**에 대한 서브골 진행도 계산 후 포함하여 반환

### Result
- 상세 메인골 조회 API가 정상 동작
- 잘못된 입력에 대한 검증 ➜ 에러 응답 동작

### Next Step
- 서브골 진행도 계산 로직 분리