### PR TITLE
feature: 서브골 생성 api 구현 및 서비스 테스트 코드 작성

### DIFF
--- a/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
@@ -1,0 +1,35 @@
+package com.org.candoit.domain.subgoal.controller;
+
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+//import com.org.candoit.domain.subgoal.service.SubGoalService;
+import com.org.candoit.domain.subgoal.service.SubGoalService;
+import com.org.candoit.global.annotation.LoginMember;
+import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class SubGoalController {
+
+    private final SubGoalService subGoalService;
+
+    @PostMapping("/main-goals/{mainGoalId}/sub-goals")
+    public ResponseEntity<ApiResponse<SimpleSubGoalInfoResponse>> createSubGoal(@Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long mainGoalId,  @Valid @RequestBody CreateSubGoalRequest createSubGoalRequest) {
+
+        SimpleSubGoalInfoResponse result = subGoalService.createSubGoal(loginMember, mainGoalId, createSubGoalRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/CreateSubGoalRequest.java
@@ -2,8 +2,10 @@ package com.org.candoit.domain.subgoal.dto;
 
 import com.org.candoit.domain.dailyaction.dto.CreateDailyActionRequest;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class CreateSubGoalRequest {
 

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -1,0 +1,81 @@
+package com.org.candoit.domain.subgoal.service;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.dailyprogress.entity.DailyProgress;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
+import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import com.org.candoit.domain.subprogress.entity.SubProgress;
+import com.org.candoit.domain.subprogress.repository.SubProgressRepository;
+import com.org.candoit.global.response.CustomException;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class SubGoalService {
+
+    private final SubGoalRepository subGoalRepository;
+    private final MainGoalCustomRepository mainGoalCustomRepository;
+    private final SubProgressRepository subProgressRepository;
+    private final DailyActionRepository dailyActionRepository;
+    private final DailyProgressRepository dailyProgressRepository;
+
+    public SimpleSubGoalInfoResponse createSubGoal(Member loginMember, Long mainGoalId,
+        CreateSubGoalRequest createSubGoalRequest) {
+
+        MainGoal mainGoal = mainGoalCustomRepository.findByMainGoalIdAndMemberId(mainGoalId,
+            loginMember.getMemberId()).orElseThrow(() -> new CustomException(
+            MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
+
+        SubGoal subGoal = SubGoal.builder()
+            .mainGoal(mainGoal)
+            .subGoalName(createSubGoalRequest.getName())
+            .isStore(Boolean.FALSE)
+            .slotNum(mainGoal.getSubGoals().size() + 1)
+            .build();
+        SubGoal savedSubGoal = subGoalRepository.save(subGoal);
+
+        SubProgress subProgress = SubProgress.builder()
+            .subGoal(savedSubGoal)
+            .checkedCount(0)
+            .targetCount(0)
+            .build();
+        subProgressRepository.save(subProgress);
+
+        if(!createSubGoalRequest.getDailyActions().isEmpty()){
+            List<DailyAction> dailyActions = createSubGoalRequest.getDailyActions().stream()
+                .map(dailyAction ->
+                    DailyAction.builder()
+                        .dailyActionTitle(dailyAction.getTitle())
+                        .content(dailyAction.getContent())
+                        .subGoal(savedSubGoal)
+                        .targetNum(dailyAction.getTargetNum())
+                        .isStore(Boolean.FALSE)
+                        .build())
+                .collect(Collectors.toList());
+
+            List<DailyAction> savedDailyActions = dailyActionRepository.saveAll(dailyActions);
+
+            List<DailyProgress> dailyProgresses = savedDailyActions.stream()
+                .map(dailyAction -> DailyProgress.builder().dailyAction(dailyAction).build())
+                .collect(Collectors.toList());
+
+            dailyProgressRepository.saveAll(dailyProgresses);
+        }
+
+        return new SimpleSubGoalInfoResponse(savedSubGoal.getSubGoalId(),
+            savedSubGoal.getSubGoalName());
+    }
+}

--- a/src/test/java/com/org/candoit/CandoitApplicationTests.java
+++ b/src/test/java/com/org/candoit/CandoitApplicationTests.java
@@ -1,10 +1,10 @@
 package com.org.candoit;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@Disabled
+@ActiveProfiles("test")
 @SpringBootTest
 class CandoitApplicationTests {
 

--- a/src/test/java/com/org/candoit/subgoal/service/SubGoalServiceTest.java
+++ b/src/test/java/com/org/candoit/subgoal/service/SubGoalServiceTest.java
@@ -1,0 +1,115 @@
+package com.org.candoit.subgoal.service;
+
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
+import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import com.org.candoit.domain.subgoal.service.SubGoalService;
+import com.org.candoit.domain.subprogress.entity.SubProgress;
+import com.org.candoit.domain.subprogress.repository.SubProgressRepository;
+import com.org.candoit.global.response.CustomException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SubGoalServiceTest {
+
+    @Mock
+    SubGoalRepository subGoalRepository;
+    @Mock
+    MainGoalCustomRepository mainGoalCustomRepository;
+    @Mock
+    SubProgressRepository subProgressRepository;
+    @Mock
+    DailyProgressRepository dailyProgressRepository;
+    @Mock
+    DailyActionRepository dailyActionRepository;
+
+    @InjectMocks
+    SubGoalService subGoalService;
+
+    Member loginMember;
+
+    @BeforeEach
+    void setUp() {
+        loginMember = Member.builder()
+            .memberId(1l)
+            .build();
+    }
+
+    @Test
+    @DisplayName("데일리 액션이 없을 때, 서브골 저장 성공")
+    void createSubGoal_success_withoutDailyAction() {
+        // given
+        List<SubGoal> alreadySavedSubGoals = new ArrayList<>();
+        for (long i = 0; i < 5; i++) {
+            alreadySavedSubGoals.add(SubGoal.builder().subGoalId(i).build());
+        }
+        MainGoal mainGoal = MainGoal.builder()
+            .mainGoalId(1l)
+            .subGoals(alreadySavedSubGoals)
+            .build();
+
+        when(mainGoalCustomRepository.findByMainGoalIdAndMemberId(mainGoal.getMainGoalId(),
+            loginMember.getMemberId())).thenReturn(
+            Optional.of(mainGoal));
+
+        CreateSubGoalRequest request = new CreateSubGoalRequest("subGoal", List.of());
+        SubGoal create = SubGoal.builder()
+            .subGoalName(request.getName())
+            .slotNum(alreadySavedSubGoals.size() + 1)
+            .build();
+
+        when(subGoalRepository.save(any(SubGoal.class))).thenReturn(create);
+
+        // when
+        SimpleSubGoalInfoResponse result = subGoalService.createSubGoal(loginMember, mainGoal.getMainGoalId(), request);
+
+        // then
+        assertEquals(request.getName(), result.getName());
+        verify(subProgressRepository).save(any(SubProgress.class));
+        verifyNoInteractions(dailyActionRepository, dailyProgressRepository);
+    }
+
+    @Test
+    @DisplayName("일치하는 메인골이 없어 서브골 생성에 실패한다.")
+    void givenNotMatchMainGoalId_whenCreateSubGoal_thenThrowNotFoundException() {
+        // given
+        when(mainGoalCustomRepository.findByMainGoalIdAndMemberId(anyLong(), anyLong())).thenReturn(
+            Optional.empty());
+        CreateSubGoalRequest request = new CreateSubGoalRequest("subGoal", List.of());
+
+        // when, then
+        assertThatThrownBy(() -> subGoalService.createSubGoal(loginMember, 1l, request))
+            .isInstanceOf(CustomException.class)
+            .hasMessageContaining(MainGoalErrorCode.NOT_FOUND_MAIN_GOAL.getMessage())
+            .extracting("errorCode")
+            .isEqualTo(MainGoalErrorCode.NOT_FOUND_MAIN_GOAL);
+
+    }
+
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #77 
## 👩🏻‍💻 구현 내용
### Problem
- 서브골 생성 api 필요

### Approach
**① 서브골 생성 api 구현**
- 메인골에 생성되어있는 서브골의 개수 + 1 을 사용해 서브골 위치를 저장.
- 서브 프로그레스 저장. 서브골과 서브 프로그레스의 생성 시점을 동일하게 함.
  ➜ 이후 서브 프로그레스 기능 사용 시, 만들어진 객체를 사용하기 위함.
- 데일리 액션 없는 경우
  - 가져오기 기능을 사용하지 않는 경우, 요청 값에 데일리 액션 값이 존재하지 않으므로 해당 경우를 처리

**② 테스트 코드 작성**
- slotNum이 예상 값으로 올바르게 저장되는지 확인하기 위해 테스트 코드를 작성
- 테스트 코드 작성을 위해 @ Disabled 어노테이션 제거

### Result
- slotNum이 올바르게 저장됨.
- 테스트 코드 통과