### PR TITLE
fix: @SpringBootTest 제거

### DIFF
--- a/src/test/java/com/org/candoit/CandoitApplicationTests.java
+++ b/src/test/java/com/org/candoit/CandoitApplicationTests.java
@@ -1,11 +1,7 @@
 package com.org.candoit;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
-@ActiveProfiles("test")
-@SpringBootTest
 class CandoitApplicationTests {
 
     @Test


### PR DESCRIPTION
## 📌 이슈 번호
- #77 

## 👩🏻‍💻 구현 내용
### Problem
- `@ SpringBootTest` 어노테이션 사용 시, 전체 스프링 컨텍스트 로드가 수행됨.
- 이 때, 테스트 관련 yml 파일 부재로 **설정 값을 필요로 하는 바인딩 실패**가 발생해 CI가 중단되는 문제 발생함.

### Approach
- 아직 테스트 코드가 없으므로, 우선 `@ SpringBootTest` 어노테이션을 제거해 컨텍스트 로드를 방지하도록 임시 조치

### Result
- CI/CD가 정상적으로 진행됨.

### Next Step
- 이후 테스트 코드 작성 시, `application-test.yml` 파일을 추해 관련 문제를 해결하고, 커버리지 확보를 위한 테스트 환경을 구축할 예정