### PR TITLE
feature: 서브골 수정 api 구현 및 서비스 단위 테스트 작성

### DIFF
--- a/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
@@ -2,8 +2,9 @@ package com.org.candoit.domain.subgoal.controller;
 
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.SimpleInfoWithAttainmentResponse;
 import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
-//import com.org.candoit.domain.subgoal.service.SubGoalService;
+import com.org.candoit.domain.subgoal.dto.UpdateSubGoalRequest;
 import com.org.candoit.domain.subgoal.service.SubGoalService;
 import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
@@ -12,6 +13,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -26,10 +28,23 @@ public class SubGoalController {
     private final SubGoalService subGoalService;
 
     @PostMapping("/main-goals/{mainGoalId}/sub-goals")
-    public ResponseEntity<ApiResponse<SimpleSubGoalInfoResponse>> createSubGoal(@Parameter(hidden = true) @LoginMember Member loginMember,
-        @PathVariable Long mainGoalId,  @Valid @RequestBody CreateSubGoalRequest createSubGoalRequest) {
+    public ResponseEntity<ApiResponse<SimpleSubGoalInfoResponse>> createSubGoal(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long mainGoalId,
+        @Valid @RequestBody CreateSubGoalRequest createSubGoalRequest) {
 
-        SimpleSubGoalInfoResponse result = subGoalService.createSubGoal(loginMember, mainGoalId, createSubGoalRequest);
+        SimpleSubGoalInfoResponse result = subGoalService.createSubGoal(loginMember, mainGoalId,
+            createSubGoalRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/sub-goals/{subGoalId}")
+    public ResponseEntity<ApiResponse<SimpleInfoWithAttainmentResponse>> updateSubGoal(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long subGoalId,
+        @Valid @RequestBody UpdateSubGoalRequest updateSubGoalRequest) {
+
+        SimpleInfoWithAttainmentResponse result = subGoalService.updateSubGoal(loginMember, subGoalId, updateSubGoalRequest);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/SimpleInfoWithAttainmentResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/SimpleInfoWithAttainmentResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimpleInfoWithAttainmentResponse {
+    private Long id;
+    private String name;
+    private Boolean attainment;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/UpdateSubGoalRequest.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/UpdateSubGoalRequest.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@AllArgsConstructor
+@Setter
+@Getter
+public class UpdateSubGoalRequest {
+    @NotNull
+    private String name;
+    @NotNull
+    private Boolean attainment;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
@@ -47,4 +47,9 @@ public class SubGoal extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "subGoal", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<DailyAction> dailyActions = new ArrayList<>();
+
+    public void changeSubGoalProperty(String name, Boolean attainment){
+        this.subGoalName = name;
+        this.isStore = attainment;
+    }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -9,8 +9,12 @@ import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
 import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.SimpleInfoWithAttainmentResponse;
 import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import com.org.candoit.domain.subgoal.dto.UpdateSubGoalRequest;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.exception.SubGoalErrorCode;
+import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
 import com.org.candoit.domain.subprogress.entity.SubProgress;
 import com.org.candoit.domain.subprogress.repository.SubProgressRepository;
@@ -27,6 +31,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubGoalService {
 
     private final SubGoalRepository subGoalRepository;
+    private final SubGoalCustomRepository subGoalCustomRepository;
     private final MainGoalCustomRepository mainGoalCustomRepository;
     private final SubProgressRepository subProgressRepository;
     private final DailyActionRepository dailyActionRepository;
@@ -54,7 +59,7 @@ public class SubGoalService {
             .build();
         subProgressRepository.save(subProgress);
 
-        if(!createSubGoalRequest.getDailyActions().isEmpty()){
+        if (!createSubGoalRequest.getDailyActions().isEmpty()) {
             List<DailyAction> dailyActions = createSubGoalRequest.getDailyActions().stream()
                 .map(dailyAction ->
                     DailyAction.builder()
@@ -77,5 +82,18 @@ public class SubGoalService {
 
         return new SimpleSubGoalInfoResponse(savedSubGoal.getSubGoalId(),
             savedSubGoal.getSubGoalName());
+    }
+
+    public SimpleInfoWithAttainmentResponse updateSubGoal(Member loginMember, Long subGoalId,
+        UpdateSubGoalRequest updateSubGoalRequest) {
+
+        SubGoal updateSubgoal = subGoalCustomRepository.findByMemberIdAndSubGoalId(
+                loginMember.getMemberId(), subGoalId)
+            .orElseThrow(() -> new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+
+        updateSubgoal.changeSubGoalProperty(updateSubGoalRequest.getName(),
+            updateSubGoalRequest.getAttainment());
+        return new SimpleInfoWithAttainmentResponse(updateSubgoal.getSubGoalId(),
+            updateSubgoal.getSubGoalName(), updateSubGoalRequest.getAttainment());
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #82 

## 👩🏻‍💻 구현 내용
### Problem
- 서브골 수정 api가 필요
### Approach
- JPA의 더티체킹을 사용해 서브골 수정을 구현함.
### Result
- 정상적으로 서브골 수정이 진행됨.