### PR TITLE
feature: 서브골 삭제 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -45,6 +46,16 @@ public class SubGoalController {
         @Valid @RequestBody UpdateSubGoalRequest updateSubGoalRequest) {
 
         SimpleInfoWithAttainmentResponse result = subGoalService.updateSubGoal(loginMember, subGoalId, updateSubGoalRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @DeleteMapping("/sub-goals/{subGoalId}")
+    public ResponseEntity<ApiResponse<Boolean>> deleteSubGoal(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long subGoalId
+    ){
+
+        Boolean result = subGoalService.deleteSubGoal(loginMember, subGoalId);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -79,4 +79,10 @@ public class SubGoalService {
         return new SimpleInfoWithAttainmentResponse(updateSubgoal.getSubGoalId(),
             updateSubgoal.getSubGoalName(), updateSubGoalRequest.getAttainment());
     }
+
+    public Boolean deleteSubGoal(Member loginMember, Long subGoalId){
+        subGoalCustomRepository.findByMemberIdAndSubGoalId(loginMember.getMemberId(), subGoalId).orElseThrow(()->new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+        subGoalRepository.deleteById(subGoalId);
+        return Boolean.TRUE;
+    }
 }

--- a/src/test/java/com/org/candoit/subgoal/repository/SubGoalRepositoryTest.java
+++ b/src/test/java/com/org/candoit/subgoal/repository/SubGoalRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.org.candoit.subgoal.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberRole;
+import com.org.candoit.domain.member.entity.MemberStatus;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+class SubGoalRepositoryTest {
+
+    private static final Logger log = LoggerFactory.getLogger(SubGoalRepositoryTest.class);
+    @Autowired SubGoalRepository subGoalRepository;
+    @Autowired DailyActionRepository dailyActionRepository;
+    @Autowired TestEntityManager tm;
+
+    @Test
+    void givenSubGoalAndDailyAction_whenDeleteSubGoal_thenDeleteBoth() {
+        // given
+        Member member = tm.persist(Member.builder()
+            .email("test@email.com")
+            .nickname("닉네임")
+            .password("password")
+            .memberRole(MemberRole.ROLE_USER)
+            .memberStatus(MemberStatus.ACTIVITY)
+            .build());
+
+        MainGoal mainGoal = tm.persist(MainGoal.builder()
+            .member(member)
+            .mainGoalName("메인골")
+            .mainGoalStatus(MainGoalStatus.ACTIVITY)
+            .isRepresentative(false)
+            .build());
+
+        SubGoal subGoal = tm.persist(SubGoal.builder()
+            .mainGoal(mainGoal)
+            .subGoalName("서브골")
+            .isStore(false)
+            .slotNum(1)
+            .build());
+
+        for (int i = 0; i < 5; i++) {
+            tm.persist(DailyAction.builder()
+                .dailyActionTitle("데일리 액션 " + i)
+                .subGoal(subGoal)
+                .targetNum(4)
+                .isStore(false)
+                .content("내용")
+                .build());
+        }
+
+        tm.flush(); tm.clear();
+        Long subGoalId = subGoal.getSubGoalId();
+
+        // when
+        subGoalRepository.deleteById(subGoalId);
+        tm.flush(); tm.clear();
+
+        // then
+        assertTrue(subGoalRepository.findById(subGoalId).isEmpty());
+
+        Long cnt = ((Number) tm.getEntityManager()
+            .createNativeQuery("SELECT COUNT(*) FROM daily_action WHERE sub_goal_id = :id")
+            .setParameter("id", subGoalId)
+            .getSingleResult()).longValue();
+        assertEquals(0L, cnt);
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #84 
## 👩🏻‍💻 구현 내용
### Problem
- 서브골 삭제 api가 필요

### Approach
- JPA의 쿼리 메소드를 사용해 서브골 삭제 api를 구현
- 삭제 전파가 되는지 확인하기 위해 레포지토리 테스트 코드 작성

### Result
- 애플리케이션, 테스트 환경에서 정상적으로 삭제가 되는 것을 확인함.