### PR TITLE
fix: 레포지토리 테스트 에러 해결

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/entity/DailyAction.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/entity/DailyAction.java
@@ -15,6 +15,8 @@ import lombok.Builder;
 import lombok.Builder.Default;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -41,5 +43,6 @@ public class DailyAction {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sub_goal_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private SubGoal subGoal;
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/entity/DailyProgress.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/entity/DailyProgress.java
@@ -16,6 +16,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -33,5 +35,6 @@ public class DailyProgress extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "daily_action_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private DailyAction dailyAction;
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
@@ -17,6 +17,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -46,6 +48,7 @@ public class MainGoal extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     public void uncheckRepresentation(){

--- a/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/entity/SubGoal.java
@@ -15,6 +15,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -39,6 +41,7 @@ public class SubGoal extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "main_goal_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private MainGoal mainGoal;
 
     public void changeSubGoalProperty(String name, Boolean attainment){

--- a/src/test/java/com/org/candoit/subgoal/repository/SubGoalRepositoryTest.java
+++ b/src/test/java/com/org/candoit/subgoal/repository/SubGoalRepositoryTest.java
@@ -20,7 +20,9 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 class SubGoalRepositoryTest {

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,13 +1,15 @@
 spring:
+  test:
+    database:
+      replace: none
   datasource:
     driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
     url: jdbc:tc:mysql:8.0.36:///test
   jpa:
     hibernate:
-      ddl-auto: create
-    properties:
-      hibernate:
-        format_sql: true
+      ddl-auto: create-drop
+  flyway:
+    enabled: false
 
 
 logging:


### PR DESCRIPTION
## 📌 이슈 번호
- #84 
## 👩🏻‍💻 구현 내용
### Problem
- CI/CD 과정에서 레포지토리 테스트에서 오류 발생

### Approach
**① 테스트 환경 분리**
- `application-test.ym`l에서 테스트 전용 설정 분리
  - `spring.jpa.hiberate.ddl-auto : create-drop`
  - 테스트 DB는 엔티티를 기반으로 생성 및 삭제

**② 엔티티 수정**
- 테스트 환경에서의 사용을 위해 엔티티를 flyway와 동일하게 단방향으로 변경
- `@OnDelete(action = OnDeleteAction.CASCADE)`를 사용해 삭제 전파 반영
### Result
- 테스트 환경 분리로 CI에서도 스키마 정상 생성 및 테스트 통과
### Learned
- **단방향 관계에서도 삭제 전파가 가능**
삭제 전파는 양방향 관계에서만 가능하다고 생각해 양방향으로 설정했으나, 이번 기회에 단방향 관계에서도 <code>@OnDelete(action = OnDeleteAction.CASCADE)</code>를 사용해 삭제 전파가 가능함을 알게 되었습니다.

- **환경 분리 필요성**
테스트 환경에서의 yml 파일을 작성하지 않아 애플리케이션에 적용되는 yml 파일이 적용되어 문제가 발생했습니다.
애플리케이션의 yml은 `ddl-auto: none`, `flyway: enabled: true`로 엔티티 기반으로 테이블을 생성하지 않기 때문에 테스트 DB에 스키마가 만들어지지 않았고, 그 결과 레포지토리 테스트가 실패했습니다.