### PR TITLE
feature: 서브골 상세조회 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/SimpleDailyActionInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/SimpleDailyActionInfoResponse.java
@@ -1,10 +1,12 @@
 package com.org.candoit.domain.dailyaction.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class SimpleDailyActionInfoResponse {
 
     private Long id;

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
@@ -1,9 +1,11 @@
 package com.org.candoit.domain.dailyaction.repository;
 
+import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import java.util.List;
 
 public interface DailyActionCustomRepository {
 
     List<DailyAction> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId);
+    List<SimpleDailyActionInfoResponse> getSimpleDailyActionInfo(Long subGoalId);
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
@@ -33,10 +33,10 @@ public class DailyActionCustomRepositoryImpl implements DailyActionCustomReposit
     @Override
     public List<SimpleDailyActionInfoResponse> getSimpleDailyActionInfo(Long subGoalId) {
         return jpaQueryFactory.select(Projections.constructor(SimpleDailyActionInfoResponse.class,
-            dailyAction.dailyActionId,
-            dailyAction.dailyActionTitle,
-            dailyAction.content,
-            dailyAction.targetNum
+                dailyAction.dailyActionId,
+                dailyAction.dailyActionTitle,
+                dailyAction.content,
+                dailyAction.targetNum
             )).from(dailyAction)
             .innerJoin(dailyAction.subGoal, subGoal)
             .on(dailyAction.subGoal.subGoalId.eq(subGoalId))

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
@@ -4,7 +4,9 @@ import static com.org.candoit.domain.dailyaction.entity.QDailyAction.dailyAction
 import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
 import static com.org.candoit.domain.subgoal.entity.QSubGoal.subGoal;
 
+import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +27,19 @@ public class DailyActionCustomRepositoryImpl implements DailyActionCustomReposit
             .on(mainGoal.mainGoalId.eq(subGoal.mainGoal.mainGoalId))
             .where(subGoal.subGoalId.eq(subGoalId).and(mainGoal.member.memberId.eq(memberId)
             ))
+            .fetch();
+    }
+
+    @Override
+    public List<SimpleDailyActionInfoResponse> getSimpleDailyActionInfo(Long subGoalId) {
+        return jpaQueryFactory.select(Projections.constructor(SimpleDailyActionInfoResponse.class,
+            dailyAction.dailyActionId,
+            dailyAction.dailyActionTitle,
+            dailyAction.content,
+            dailyAction.targetNum
+            )).from(dailyAction)
+            .innerJoin(dailyAction.subGoal, subGoal)
+            .on(dailyAction.subGoal.subGoalId.eq(subGoalId))
             .fetch();
     }
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/dto/DailyProgressResponse.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/dto/DailyProgressResponse.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.dailyprogress.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DailyProgressResponse {
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<LocalDate> dailyProgress;
+}

--- a/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepository.java
@@ -1,0 +1,9 @@
+package com.org.candoit.domain.dailyprogress.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface DailyProgressCustomRepository {
+
+    List<LocalDate> distinctCheckedDate(Long subGoalId, LocalDate start, LocalDate end);
+}

--- a/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.org.candoit.domain.dailyprogress.repository;
+
+import static com.org.candoit.domain.dailyaction.entity.QDailyAction.dailyAction;
+import static com.org.candoit.domain.dailyprogress.entity.QDailyProgress.dailyProgress;
+
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class DailyProgressCustomRepositoryImpl implements DailyProgressCustomRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<LocalDate> distinctCheckedDate(Long subGoalId, LocalDate start, LocalDate end) {
+        return jpaQueryFactory.select(dailyProgress.checkedDate).distinct()
+            .from(dailyProgress)
+            .where(
+                dailyProgress.checkedDate.between(start, end),
+                JPAExpressions.selectOne()
+                    .from(dailyAction)
+                    .where(dailyAction.dailyActionId.eq(dailyProgress.dailyAction.dailyActionId),
+                        dailyAction.subGoal.subGoalId.eq(subGoalId))
+                    .exists()
+            ).fetch();
+    }
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
@@ -2,6 +2,7 @@ package com.org.candoit.domain.subgoal.controller;
 
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.DetailSubGoalResponse;
 import com.org.candoit.domain.subgoal.dto.SimpleInfoWithAttainmentResponse;
 import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
 import com.org.candoit.domain.subgoal.dto.UpdateSubGoalRequest;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -56,6 +58,15 @@ public class SubGoalController {
     ){
 
         Boolean result = subGoalService.deleteSubGoal(loginMember, subGoalId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/sub-goals/{subGoalId}")
+    public ResponseEntity<ApiResponse<DetailSubGoalResponse>> getSubGoal(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long subGoalId, @RequestParam String period
+    ){
+        DetailSubGoalResponse result = subGoalService.getDetailSubGoal(loginMember, subGoalId, period);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/controller/SubGoalController.java
@@ -47,7 +47,8 @@ public class SubGoalController {
         @PathVariable Long subGoalId,
         @Valid @RequestBody UpdateSubGoalRequest updateSubGoalRequest) {
 
-        SimpleInfoWithAttainmentResponse result = subGoalService.updateSubGoal(loginMember, subGoalId, updateSubGoalRequest);
+        SimpleInfoWithAttainmentResponse result = subGoalService.updateSubGoal(loginMember,
+            subGoalId, updateSubGoalRequest);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
@@ -55,7 +56,7 @@ public class SubGoalController {
     public ResponseEntity<ApiResponse<Boolean>> deleteSubGoal(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId
-    ){
+    ) {
 
         Boolean result = subGoalService.deleteSubGoal(loginMember, subGoalId);
         return ResponseEntity.ok(ApiResponse.success(result));
@@ -65,8 +66,9 @@ public class SubGoalController {
     public ResponseEntity<ApiResponse<DetailSubGoalResponse>> getSubGoal(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId, @RequestParam String period
-    ){
-        DetailSubGoalResponse result = subGoalService.getDetailSubGoal(loginMember, subGoalId, period);
+    ) {
+        DetailSubGoalResponse result = subGoalService.getDetailSubGoal(loginMember, subGoalId,
+            period);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/DetailSubGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/DetailSubGoalResponse.java
@@ -1,0 +1,17 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
+import com.org.candoit.domain.dailyprogress.dto.DailyProgressResponse;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class DetailSubGoalResponse {
+    private SubGoalPreviewResponse subGoal;
+    private List<SimpleDailyActionInfoResponse> dailyActions;
+    private DailyProgressResponse progress;
+}

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -6,7 +6,6 @@ import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository
 import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
 import com.org.candoit.domain.dailyprogress.dto.DailyProgressResponse;
 import com.org.candoit.domain.dailyprogress.repository.DailyProgressCustomRepository;
-import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
 import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
@@ -22,7 +21,6 @@ import com.org.candoit.domain.subgoal.exception.SubGoalErrorCode;
 import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
 import com.org.candoit.global.response.CustomException;
-import com.org.candoit.global.util.DateTimeUtil;
 import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -1,20 +1,32 @@
 package com.org.candoit.domain.subgoal.service;
 
+import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository;
 import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.dailyprogress.dto.DailyProgressResponse;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressCustomRepository;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
 import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.dto.CreateSubGoalRequest;
+import com.org.candoit.domain.subgoal.dto.DetailSubGoalResponse;
 import com.org.candoit.domain.subgoal.dto.SimpleInfoWithAttainmentResponse;
 import com.org.candoit.domain.subgoal.dto.SimpleSubGoalInfoResponse;
+import com.org.candoit.domain.subgoal.dto.SubGoalPreviewResponse;
 import com.org.candoit.domain.subgoal.dto.UpdateSubGoalRequest;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.domain.subgoal.exception.SubGoalErrorCode;
 import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
 import com.org.candoit.global.response.CustomException;
+import com.org.candoit.global.util.DateTimeUtil;
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +42,9 @@ public class SubGoalService {
     private final SubGoalCustomRepository subGoalCustomRepository;
     private final MainGoalCustomRepository mainGoalCustomRepository;
     private final DailyActionRepository dailyActionRepository;
+    private final DailyActionCustomRepository dailyActionCustomRepository;
+    private final Clock clock;
+    private final DailyProgressCustomRepository dailyProgressCustomRepository;
 
     public SimpleSubGoalInfoResponse createSubGoal(Member loginMember, Long mainGoalId,
         CreateSubGoalRequest createSubGoalRequest) {
@@ -38,7 +53,8 @@ public class SubGoalService {
             loginMember.getMemberId()).orElseThrow(() -> new CustomException(
             MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
 
-        int alreadySavedSubGoalSize = subGoalCustomRepository.findByMainGoalId(mainGoal.getMainGoalId()).size();
+        int alreadySavedSubGoalSize = subGoalCustomRepository.findByMainGoalId(
+            mainGoal.getMainGoalId()).size();
 
         SubGoal subGoal = SubGoal.builder()
             .mainGoal(mainGoal)
@@ -80,9 +96,61 @@ public class SubGoalService {
             updateSubgoal.getSubGoalName(), updateSubGoalRequest.getAttainment());
     }
 
-    public Boolean deleteSubGoal(Member loginMember, Long subGoalId){
-        subGoalCustomRepository.findByMemberIdAndSubGoalId(loginMember.getMemberId(), subGoalId).orElseThrow(()->new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+    public Boolean deleteSubGoal(Member loginMember, Long subGoalId) {
+        subGoalCustomRepository.findByMemberIdAndSubGoalId(loginMember.getMemberId(), subGoalId)
+            .orElseThrow(() -> new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
         subGoalRepository.deleteById(subGoalId);
         return Boolean.TRUE;
+    }
+
+    public DetailSubGoalResponse getDetailSubGoal(Member loginMember, Long subGoalId,
+        String period) {
+        SubGoal subGoal = subGoalCustomRepository.findByMemberIdAndSubGoalId(
+                loginMember.getMemberId(), subGoalId)
+            .orElseThrow(() -> new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+        SubGoalPreviewResponse subGoalPreviewResponse = SubGoalPreviewResponse.builder()
+            .id(subGoal.getSubGoalId())
+            .name(subGoal.getSubGoalName())
+            .slotNum(subGoal.getSlotNum())
+            .attainment(subGoal.getIsStore())
+            .build();
+        List<SimpleDailyActionInfoResponse> dailyActions = dailyActionCustomRepository.getSimpleDailyActionInfo(
+            subGoalId);
+
+        DailyProgressResponse dailyProgressResponse;
+
+        LocalDate now = LocalDate.now(clock);
+        LocalDate startDay = LocalDate.now();
+        LocalDate endDay = LocalDate.now();
+
+        // 데일리 액션이 없는 경우
+        if (dailyActions.isEmpty()) {
+            dailyActions = List.of();
+            dailyProgressResponse = new DailyProgressResponse(startDay, endDay, List.of());
+        }
+        // 데일리 액션이 있는 경우
+        else {
+
+            if ("week".equals(period)) {
+                startDay = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+                endDay = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+            } else if ("month".equals(period)) {
+                startDay = now.with(TemporalAdjusters.firstDayOfMonth());
+                endDay = now.with(TemporalAdjusters.lastDayOfMonth());
+            }
+            List<LocalDate> checkedDate = dailyProgressCustomRepository.distinctCheckedDate(
+                subGoalId, startDay, endDay);
+
+            dailyProgressResponse = DailyProgressResponse.builder()
+                .startDate(startDay)
+                .endDate(endDay)
+                .dailyProgress(checkedDate)
+                .build();
+        }
+        return DetailSubGoalResponse.builder()
+            .subGoal(subGoalPreviewResponse)
+            .dailyActions(dailyActions)
+            .progress(dailyProgressResponse)
+            .build();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #88 
## 👩🏻‍💻 구현 내용
### Problem
- 서브골 상세 조회 api 필요

### Approach
**① 기간 별 서브골 스트릭 조회** 
- period를 `month`, `week` 값을 요청 받음. (@ RequestParam)
- 해당 서브골에 존재하는 dailyAction이 없는 경우, List.of()를 통해 빈 배열을 응답하도록 함.

### Result
- 주간, 월간 단위로 서브골 상세조회가 정상 응답함.