### PR TITLE
fix: dailyAction 응답에 attainment 추가

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/DailyActionInfoWithAttainmentResponse.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/DailyActionInfoWithAttainmentResponse.java
@@ -1,0 +1,16 @@
+package com.org.candoit.domain.dailyaction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DailyActionInfoWithAttainmentResponse {
+    private Long id;
+    private String title;
+    private String content;
+    private Integer targetNum;
+    private Boolean attainment;
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
@@ -1,11 +1,11 @@
 package com.org.candoit.domain.dailyaction.repository;
 
-import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import java.util.List;
 
 public interface DailyActionCustomRepository {
 
     List<DailyAction> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId);
-    List<SimpleDailyActionInfoResponse> getSimpleDailyActionInfo(Long subGoalId);
+    List<DailyActionInfoWithAttainmentResponse> getSimpleDailyActionInfo(Long subGoalId);
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
@@ -4,6 +4,7 @@ import static com.org.candoit.domain.dailyaction.entity.QDailyAction.dailyAction
 import static com.org.candoit.domain.maingoal.entity.QMainGoal.mainGoal;
 import static com.org.candoit.domain.subgoal.entity.QSubGoal.subGoal;
 
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
 import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import com.querydsl.core.types.Projections;
@@ -31,12 +32,13 @@ public class DailyActionCustomRepositoryImpl implements DailyActionCustomReposit
     }
 
     @Override
-    public List<SimpleDailyActionInfoResponse> getSimpleDailyActionInfo(Long subGoalId) {
-        return jpaQueryFactory.select(Projections.constructor(SimpleDailyActionInfoResponse.class,
+    public List<DailyActionInfoWithAttainmentResponse> getSimpleDailyActionInfo(Long subGoalId) {
+        return jpaQueryFactory.select(Projections.constructor(DailyActionInfoWithAttainmentResponse.class,
                 dailyAction.dailyActionId,
                 dailyAction.dailyActionTitle,
                 dailyAction.content,
-                dailyAction.targetNum
+                dailyAction.targetNum,
+                dailyAction.isStore
             )).from(dailyAction)
             .innerJoin(dailyAction.subGoal, subGoal)
             .on(dailyAction.subGoal.subGoalId.eq(subGoalId))

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/DetailSubGoalResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/DetailSubGoalResponse.java
@@ -1,5 +1,6 @@
 package com.org.candoit.domain.subgoal.dto;
 
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
 import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
 import com.org.candoit.domain.dailyprogress.dto.DailyProgressResponse;
 import java.util.List;
@@ -12,6 +13,6 @@ import lombok.Getter;
 @Builder
 public class DetailSubGoalResponse {
     private SubGoalPreviewResponse subGoal;
-    private List<SimpleDailyActionInfoResponse> dailyActions;
+    private List<DailyActionInfoWithAttainmentResponse> dailyActions;
     private DailyProgressResponse progress;
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -1,5 +1,6 @@
 package com.org.candoit.domain.subgoal.service;
 
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
 import com.org.candoit.domain.dailyaction.dto.SimpleDailyActionInfoResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository;
@@ -112,7 +113,7 @@ public class SubGoalService {
             .slotNum(subGoal.getSlotNum())
             .attainment(subGoal.getIsStore())
             .build();
-        List<SimpleDailyActionInfoResponse> dailyActions = dailyActionCustomRepository.getSimpleDailyActionInfo(
+        List<DailyActionInfoWithAttainmentResponse> dailyActions = dailyActionCustomRepository.getSimpleDailyActionInfo(
             subGoalId);
 
         DailyProgressResponse dailyProgressResponse;


### PR DESCRIPTION
## 📌 이슈 번호
- #88 

## 👩🏻‍💻 구현 내용
### Problem
- 서브골 상세 조회 api 응답에서 dailyAction의 `attainment` 필드 누락

### Approach
- 해당 DTO에 attainment 추가

### Result
- dailyAction의 attainment 필드가 포함되어 정상적으로 응답