### PR TITLE
feature: 데일리 액션 생성 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/controller/DailyActionController.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/controller/DailyActionController.java
@@ -1,0 +1,36 @@
+package com.org.candoit.domain.dailyaction.controller;
+
+import com.org.candoit.domain.dailyaction.dto.CreateDailyActionRequest;
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
+import com.org.candoit.domain.dailyaction.service.DailyActionService;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.annotation.LoginMember;
+import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api")
+@RestController
+@RequiredArgsConstructor
+public class DailyActionController {
+
+    private final DailyActionService dailyActionService;
+
+    @PostMapping("/sub-goals/{subGoalId}/daily-actions")
+    public ResponseEntity<ApiResponse<DailyActionInfoWithAttainmentResponse>> createDailyAction(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long subGoalId,
+        @Valid @RequestBody CreateDailyActionRequest dailyActionRequest) {
+
+        DailyActionInfoWithAttainmentResponse result = dailyActionService.createDailyAction(loginMember, subGoalId, dailyActionRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/CreateDailyActionRequest.java
@@ -2,15 +2,18 @@ package com.org.candoit.domain.dailyaction.dto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
+@Setter
 @Getter
 public class CreateDailyActionRequest {
 
-    @NotNull
+    @NotBlank
     private String title;
-    @NotNull
+    @NotBlank
     private String content;
     @NotNull @Min(1) @Max(7)
     private Integer targetNum;

--- a/src/main/java/com/org/candoit/domain/dailyaction/service/DailyActionService.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/service/DailyActionService.java
@@ -1,0 +1,45 @@
+package com.org.candoit.domain.dailyaction.service;
+
+import com.org.candoit.domain.dailyaction.dto.CreateDailyActionRequest;
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.exception.SubGoalErrorCode;
+import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import com.org.candoit.global.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class DailyActionService {
+
+    private final DailyActionRepository dailyActionRepository;
+    private final SubGoalCustomRepository subGoalCustomRepository;
+
+    public DailyActionInfoWithAttainmentResponse createDailyAction(Member loginMember,
+        Long subGoalId, CreateDailyActionRequest dailyActionRequest) {
+
+        SubGoal subGoal = subGoalCustomRepository.findByMemberIdAndSubGoalId(
+            loginMember.getMemberId(), subGoalId).orElseThrow(() -> new CustomException(
+            SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+
+        DailyAction dailyAction = DailyAction.builder().
+            dailyActionTitle(dailyActionRequest.getTitle())
+            .content(dailyActionRequest.getContent())
+            .subGoal(subGoal)
+            .targetNum(dailyActionRequest.getTargetNum()).build();
+
+
+        DailyAction savedDailyAction = dailyActionRepository.save(dailyAction);
+        return DailyActionInfoWithAttainmentResponse.builder()
+            .id(savedDailyAction.getDailyActionId())
+            .title(savedDailyAction.getDailyActionTitle())
+            .content(savedDailyAction.getContent())
+            .targetNum(savedDailyAction.getTargetNum())
+            .attainment(savedDailyAction.getIsStore())
+            .build();
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #90

## 👩🏻‍💻 구현 내용
### Problem
- 데일리 액션 생성 api 필요

### Approach
- requestBody로 받은 `title`, `content`, `targetNum`을 기반으로 데일리 액션을 생성함.
- @ Valid를 사용해 dto레벨에서 입력값을 검증.

### Result
- 클라이언트 요청에 따라 새로운 데일리 액션이 성공적으로 생성됨.

### Learn
- @ NotBlank: `null`, `""`, `" "` 비허용, (공백도 허용하지 않음)
- @ NotNull: `null` 비허용
- @ NotEmpty: `null`, `""` 비허용, (공백은 허용)