### PR TITLE
feature: 데일리 액션 수정 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/controller/DailyActionController.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/controller/DailyActionController.java
@@ -2,6 +2,7 @@ package com.org.candoit.domain.dailyaction.controller;
 
 import com.org.candoit.domain.dailyaction.dto.CreateDailyActionRequest;
 import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
+import com.org.candoit.domain.dailyaction.dto.UpdateDailyActionRequest;
 import com.org.candoit.domain.dailyaction.service.DailyActionService;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.global.annotation.LoginMember;
@@ -11,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +33,16 @@ public class DailyActionController {
         @Valid @RequestBody CreateDailyActionRequest dailyActionRequest) {
 
         DailyActionInfoWithAttainmentResponse result = dailyActionService.createDailyAction(loginMember, subGoalId, dailyActionRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @PatchMapping("/daily-actions/{dailyActionId}")
+    public ResponseEntity<ApiResponse<DailyActionInfoWithAttainmentResponse>> updateDailyAction(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long dailyActionId,
+        @Valid @RequestBody UpdateDailyActionRequest updateDailyActionRequest
+    ){
+        DailyActionInfoWithAttainmentResponse result = dailyActionService.updateDailyAction(loginMember, dailyActionId, updateDailyActionRequest);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/dto/UpdateDailyActionRequest.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/dto/UpdateDailyActionRequest.java
@@ -1,0 +1,25 @@
+package com.org.candoit.domain.dailyaction.dto;
+
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class UpdateDailyActionRequest {
+
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String content;
+    @NotNull @Min(1) @Max(7)
+    private Integer targetNum;
+    @NotNull
+    private Boolean attainment;
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/entity/DailyAction.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/entity/DailyAction.java
@@ -45,4 +45,11 @@ public class DailyAction {
     @JoinColumn(name = "sub_goal_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)
     private SubGoal subGoal;
+
+    public void updateDailyAction(String title, String content, Integer targetNum, Boolean attainment) {
+        this.dailyActionTitle = title;
+        this.content = content;
+        this.targetNum = targetNum;
+        this.isStore = attainment;
+    }
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/exception/DailyActionErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/exception/DailyActionErrorCode.java
@@ -1,0 +1,18 @@
+package com.org.candoit.domain.dailyaction.exception;
+
+import com.org.candoit.global.response.ErrorCode;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public enum DailyActionErrorCode implements ErrorCode {
+
+    NOT_FOUND_DAILY_ACTION(HttpStatus.NOT_FOUND,"18000", "일치하는 데일리 액션을 찾지 못했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepository.java
@@ -3,9 +3,11 @@ package com.org.candoit.domain.dailyaction.repository;
 import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import java.util.List;
+import java.util.Optional;
 
 public interface DailyActionCustomRepository {
 
     List<DailyAction> findByMemberIdAndSubGoalId(Long memberId, Long subGoalId);
     List<DailyActionInfoWithAttainmentResponse> getSimpleDailyActionInfo(Long subGoalId);
+    Optional<DailyAction> findByMemberIdAndDailyActionId(Long memberId, Long dailyActionId);
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/repository/DailyActionCustomRepositoryImpl.java
@@ -10,6 +10,7 @@ import com.org.candoit.domain.dailyaction.entity.DailyAction;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -43,5 +44,17 @@ public class DailyActionCustomRepositoryImpl implements DailyActionCustomReposit
             .innerJoin(dailyAction.subGoal, subGoal)
             .on(dailyAction.subGoal.subGoalId.eq(subGoalId))
             .fetch();
+    }
+
+    @Override
+    public Optional<DailyAction> findByMemberIdAndDailyActionId(Long memberId, Long dailyActionId) {
+        return Optional.ofNullable(jpaQueryFactory.select(dailyAction)
+            .from(dailyAction)
+            .join(dailyAction.subGoal, subGoal)
+            .join(subGoal.mainGoal, mainGoal)
+            .where(
+                dailyAction.dailyActionId.eq(dailyActionId),
+                mainGoal.member.memberId.eq(memberId)
+            ).fetchOne());
     }
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/service/DailyActionService.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/service/DailyActionService.java
@@ -2,7 +2,10 @@ package com.org.candoit.domain.dailyaction.service;
 
 import com.org.candoit.domain.dailyaction.dto.CreateDailyActionRequest;
 import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
+import com.org.candoit.domain.dailyaction.dto.UpdateDailyActionRequest;
 import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.exception.DailyActionErrorCode;
+import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository;
 import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
@@ -11,12 +14,15 @@ import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import com.org.candoit.global.response.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @RequiredArgsConstructor
 @Service
 public class DailyActionService {
 
     private final DailyActionRepository dailyActionRepository;
+    private final DailyActionCustomRepository dailyActionCustomRepository;
     private final SubGoalCustomRepository subGoalCustomRepository;
 
     public DailyActionInfoWithAttainmentResponse createDailyAction(Member loginMember,
@@ -40,6 +46,20 @@ public class DailyActionService {
             .content(savedDailyAction.getContent())
             .targetNum(savedDailyAction.getTargetNum())
             .attainment(savedDailyAction.getIsStore())
+            .build();
+    }
+
+    public DailyActionInfoWithAttainmentResponse updateDailyAction(Member loginMember, Long dailyActionId, UpdateDailyActionRequest request) {
+
+        DailyAction dailyAction = dailyActionCustomRepository.findByMemberIdAndDailyActionId(loginMember.getMemberId(), dailyActionId).orElseThrow(()->new CustomException(
+            DailyActionErrorCode.NOT_FOUND_DAILY_ACTION));
+        dailyAction.updateDailyAction(request.getTitle(), request.getContent(), request.getTargetNum(), request.getAttainment());
+        return DailyActionInfoWithAttainmentResponse.builder()
+            .id(dailyAction.getDailyActionId())
+            .title(dailyAction.getDailyActionTitle())
+            .content(dailyAction.getContent())
+            .targetNum(dailyAction.getTargetNum())
+            .attainment(dailyAction.getIsStore())
             .build();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #91 

## 👩🏻‍💻 구현 내용
### Problem
- 데일리 액션 수정 api 필요

### Approach
- 수정하려는 데일리 액션 필드를 requestBody로 요청함.
- update 메소드를 만들어 해당 객체에 대한 정보를 수정함.
- `@ transactional + jpa` 의 더티체킹으로 변경 자동 반영

### Result
- 클라이언트가 요청하는 정보로 데이터 수정