### PR TITLE
feature: 데일리 액션 삭제 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyaction/controller/DailyActionController.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/controller/DailyActionController.java
@@ -12,6 +12,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,5 +45,13 @@ public class DailyActionController {
     ){
         DailyActionInfoWithAttainmentResponse result = dailyActionService.updateDailyAction(loginMember, dailyActionId, updateDailyActionRequest);
         return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @DeleteMapping("/daily-actions/{dailyActionId}")
+    public ResponseEntity<ApiResponse<Boolean>> deleteDailyAction(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long dailyActionId
+    ){
+        return ResponseEntity.ok(ApiResponse.success(dailyActionService.deleteDailyAction(loginMember, dailyActionId)));
     }
 }

--- a/src/main/java/com/org/candoit/domain/dailyaction/service/DailyActionService.java
+++ b/src/main/java/com/org/candoit/domain/dailyaction/service/DailyActionService.java
@@ -62,4 +62,11 @@ public class DailyActionService {
             .attainment(dailyAction.getIsStore())
             .build();
     }
+
+    public Boolean deleteDailyAction(Member loginMember, Long dailyActionId) {
+        DailyAction dailyAction = dailyActionCustomRepository.findByMemberIdAndDailyActionId(loginMember.getMemberId(), dailyActionId).orElseThrow(()->new CustomException(
+            DailyActionErrorCode.NOT_FOUND_DAILY_ACTION));
+        dailyActionRepository.delete(dailyAction);
+        return Boolean.TRUE;
+    }
 }

--- a/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/service/SubGoalService.java
@@ -119,8 +119,16 @@ public class SubGoalService {
         DailyProgressResponse dailyProgressResponse;
 
         LocalDate now = LocalDate.now(clock);
-        LocalDate startDay = LocalDate.now();
-        LocalDate endDay = LocalDate.now();
+        LocalDate startDay = LocalDate.now(clock);
+        LocalDate endDay = LocalDate.now(clock);
+
+        if ("week".equals(period)) {
+            startDay = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            endDay = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        } else if ("month".equals(period)) {
+            startDay = now.with(TemporalAdjusters.firstDayOfMonth());
+            endDay = now.with(TemporalAdjusters.lastDayOfMonth());
+        }
 
         // 데일리 액션이 없는 경우
         if (dailyActions.isEmpty()) {
@@ -128,15 +136,7 @@ public class SubGoalService {
             dailyProgressResponse = new DailyProgressResponse(startDay, endDay, List.of());
         }
         // 데일리 액션이 있는 경우
-        else {
-
-            if ("week".equals(period)) {
-                startDay = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
-                endDay = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
-            } else if ("month".equals(period)) {
-                startDay = now.with(TemporalAdjusters.firstDayOfMonth());
-                endDay = now.with(TemporalAdjusters.lastDayOfMonth());
-            }
+        else{
             List<LocalDate> checkedDate = dailyProgressCustomRepository.distinctCheckedDate(
                 subGoalId, startDay, endDay);
 


### PR DESCRIPTION
## 📌 이슈 번호
- #95 

## 👩🏻‍💻 구현 내용
### Problem
- 데일리 액션을 삭제할 수 있는 API가 필요함

### Approach
- 데일리 액션 삭제 시, 연관된 데일리 프로그레스가 cascade 옵션으로 함께 삭제되도록 설정

### Result
- 클라이언트에서 특정 데일리 액션을 삭제하면 관련된 모든 데일리 프로그레스가 자동으로 제거되어 데이터 정합성 보장