### PR TITLE
feature: 데일리 액션 체크 추가 api

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
@@ -1,0 +1,34 @@
+package com.org.candoit.domain.dailyprogress.controller;
+
+import com.org.candoit.domain.dailyprogress.dto.CheckDailyProgressRequest;
+import com.org.candoit.domain.dailyprogress.service.DailyProgressService;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.annotation.LoginMember;
+import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class DailyProgressController {
+
+    private final DailyProgressService dailyProgressService;
+
+    @PostMapping("/daily-actions/{dailyActionId}/daily-progress")
+    public ResponseEntity<ApiResponse<Boolean>> checkedDate(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long dailyActionId,
+        @RequestBody CheckDailyProgressRequest checkDailyProgressRequest
+    ){
+
+        Boolean result = dailyProgressService.checkedDate(loginMember, dailyActionId, checkDailyProgressRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/org/candoit/domain/dailyprogress/dto/CheckDailyProgressRequest.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/dto/CheckDailyProgressRequest.java
@@ -1,0 +1,12 @@
+package com.org.candoit.domain.dailyprogress.dto;
+
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CheckDailyProgressRequest {
+    private Boolean isChecked;
+    private LocalDate checkedDate;
+}

--- a/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepository.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface DailyProgressCustomRepository {
 
     List<LocalDate> distinctCheckedDate(Long subGoalId, LocalDate start, LocalDate end);
+    void deleteByDailyActionIdAndCheckedDate(Long dailyActionId, LocalDate checkedDate);
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepositoryImpl.java
@@ -29,4 +29,13 @@ public class DailyProgressCustomRepositoryImpl implements DailyProgressCustomRep
                     .exists()
             ).fetch();
     }
+
+    @Override
+    public void deleteByDailyActionIdAndCheckedDate(Long dailyActionId, LocalDate checkedDate) {
+        jpaQueryFactory.delete(dailyProgress)
+            .where(dailyProgress.dailyAction.dailyActionId.eq(dailyActionId).and(
+                dailyProgress.checkedDate.eq(checkedDate)
+            )).execute();
+
+    }
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/service/DailyProgressService.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/service/DailyProgressService.java
@@ -1,0 +1,46 @@
+package com.org.candoit.domain.dailyprogress.service;
+
+import com.org.candoit.domain.dailyaction.entity.DailyAction;
+import com.org.candoit.domain.dailyaction.exception.DailyActionErrorCode;
+import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository;
+import com.org.candoit.domain.dailyprogress.dto.CheckDailyProgressRequest;
+import com.org.candoit.domain.dailyprogress.entity.DailyProgress;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressCustomRepository;
+import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DailyProgressService {
+
+    private final DailyProgressRepository dailyProgressRepository;
+    private final DailyProgressCustomRepository dailyProgressCustomRepository;
+    private final DailyActionCustomRepository dailyActionCustomRepository;
+
+    public Boolean checkedDate(Member loginMember, Long dailyActionId,
+        CheckDailyProgressRequest checkDailyProgressRequest) {
+
+        DailyAction da = dailyActionCustomRepository.findByMemberIdAndDailyActionId(
+            loginMember.getMemberId(), dailyActionId).orElseThrow(() -> new CustomException(
+            DailyActionErrorCode.NOT_FOUND_DAILY_ACTION));
+
+        // false -> 삭제
+        if (checkDailyProgressRequest.getIsChecked() == Boolean.FALSE) {
+            dailyProgressCustomRepository.deleteByDailyActionIdAndCheckedDate(da.getDailyActionId(),
+                checkDailyProgressRequest.getCheckedDate());
+        }
+        // true -> 저장
+        else {
+            dailyProgressRepository.save(DailyProgress.builder()
+                .dailyAction(da)
+                .checkedDate(checkDailyProgressRequest.getCheckedDate())
+                .build());
+        }
+        return Boolean.TRUE;
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
- #97

## 👩🏻‍💻 구현 내용
### Problem
- 데일리 프로그레스 체크 api 필요

### Approach
- requestParam으로 dailyAction을 얻음.
- requestBody로 `체크 여부(isChecked)`, `체크한 날짜(checkedDate)`를 얻음.
- `isChecked`가 false인 경우, DB에서 삭제함(해제)
- `isChecked`가 true인 경우, DB에 저장함(등록)

### Result
- 클라이언트에서 특정 날짜의 데일리 프로그레스를 등록/해제할 수 있는 단건 체크 API 제공