### PR TITLE
feature: 데일리 액션 프로그레스 목록 조회 api

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,6 +32,16 @@ public class DailyProgressController {
     ) {
         List<DetailProgressResponse> result = dailyProgressService.checkedDate(loginMember,
             subGoalId, checkDailyProgressRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/sub-goals/{subGoalId}/daily-progress")
+    public ResponseEntity<ApiResponse<List<DetailProgressResponse>>> getDailyProgress(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long subGoalId
+    ) {
+        List<DetailProgressResponse> result = dailyProgressService.getDailyProgress(loginMember,
+            subGoalId);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #99
## 👩🏻‍💻 구현 내용
### Problem
- 데일리 프로그레스 목록을 조회할 수 있는 API가 필요함

### Approach
- 기존에 등록/해제 로직에 포함되어 있던 목록 조회 메서드를 활용
- Controller에서 해당 메서드를 호출하도록 하여 API를 제공

### Result
- 클라이언트가 특정 데일리 액션에 대해 진행 현황(체크된 날짜 목록)을 조회할 수 있음
