### PR TITLE
fix: 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -138,12 +138,15 @@ public class MemberService {
         }
     }
 
-    public void withdraw(Long memberId, CheckPasswordRequest checkPasswordRequest){
+    public void withdraw(Long memberId, CheckPasswordRequest checkPasswordRequest) {
 
-        Member memberToWithdraw = memberRepository.findById(memberId).orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
+        Member memberToWithdraw = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
 
-        checkVerify(memberId, checkPasswordRequest.getType());
-
+        if (!passwordEncoder.matches(checkPasswordRequest.getPassword(),
+            memberToWithdraw.getPassword())) {
+           new CustomException(MemberErrorCode.NOT_MATCHED_PASSWORD);
+        }
         memberToWithdraw.withdraw();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #103 

## 👩🏻‍💻 구현 내용
### Problem
- 회원 탈퇴 시, 비밀번호 검증에 `checkVerify()`(용도 부적합 메서드)를 사용하여 클라이언트 요청 시, `400` 에러가 발생

### Approach
- 비밀번호 검증 로직을 교체 (`PasswordEncoder.matches(raw, encoded)` 기반 검증)
