### PR TITLE
fix: throw 누락으로 인한 오류 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -142,14 +142,10 @@ public class MemberService {
 
         Member memberToWithdraw = memberRepository.findById(memberId)
             .orElseThrow(() -> new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
-        System.out.println("raw=" + checkPasswordRequest.getPassword());
-        System.out.println("encoded=" + memberToWithdraw.getPassword());
-        System.out.println("matches=" +
-            passwordEncoder.matches(checkPasswordRequest.getPassword(), memberToWithdraw.getPassword()));
 
         if (!passwordEncoder.matches(checkPasswordRequest.getPassword(),
             memberToWithdraw.getPassword())) {
-           throw new CustomException(MemberErrorCode.NOT_MATCHED_PASSWORD);
+            throw new CustomException(MemberErrorCode.NOT_MATCHED_PASSWORD);
         }
         memberToWithdraw.withdraw();
     }

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -142,10 +142,14 @@ public class MemberService {
 
         Member memberToWithdraw = memberRepository.findById(memberId)
             .orElseThrow(() -> new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
+        System.out.println("raw=" + checkPasswordRequest.getPassword());
+        System.out.println("encoded=" + memberToWithdraw.getPassword());
+        System.out.println("matches=" +
+            passwordEncoder.matches(checkPasswordRequest.getPassword(), memberToWithdraw.getPassword()));
 
         if (!passwordEncoder.matches(checkPasswordRequest.getPassword(),
             memberToWithdraw.getPassword())) {
-           new CustomException(MemberErrorCode.NOT_MATCHED_PASSWORD);
+           throw new CustomException(MemberErrorCode.NOT_MATCHED_PASSWORD);
         }
         memberToWithdraw.withdraw();
     }


### PR DESCRIPTION
## 📌 이슈 번호
- #103

## 👩🏻‍💻 구현 내용
### Problem
- throw 키워드 누락 ➜ 비밀번호가 일치하지 않은 경우 예외가 터지지 않고, 비밀번호가 변경되는 문제 발생

### Approach
- `throw` 키워드를 작성해 조건 불일치 시 예외를 발생시키도록 수정

### Result
- 비밀번호 불일치 시 예외가 정상적으로 발생하고, 비밀번호 변경 로직이 실행되지 않음.