### PR TITLE
fix: 회원 탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/MemberUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.org.candoit.domain.member.dto;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
@@ -8,7 +9,8 @@ public class MemberUpdateRequest {
 
     private String profile_image;
     private String comment;
-    @Email
+    @Email @NotBlank
     private String email;
+    @NotBlank
     private String nickname;
 }

--- a/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
@@ -1,13 +1,15 @@
 package com.org.candoit.domain.member.repository;
 
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
-    Optional<Member> findByNickname(String nickname);
-    boolean existsByEmail(String email);
-    boolean existsByNickname(String nickname);
+    Optional<Member> findByEmailAndMemberStatus(String email, MemberStatus memberStatus);
+    Optional<Member> findByNicknameAndMemberStatus(String nickname, MemberStatus memberStatus);
+    boolean existsByEmailAndMemberStatus(String email, MemberStatus memberStatus);
+    boolean existsByNicknameAndMemberStatus(String nickname, MemberStatus memberStatus);
 }

--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -47,10 +47,10 @@ public class MemberService {
 
     private void validateDuplicateOnJoin(String email, String nickname){
 
-        if(memberRepository.existsByEmail(email)){
+        if(memberRepository.existsByEmailAndMemberStatus(email, MemberStatus.ACTIVITY)){
             throw new CustomException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
         }
-        else if(memberRepository.existsByNickname(nickname)){
+        else if(memberRepository.existsByNicknameAndMemberStatus(nickname, MemberStatus.ACTIVITY)){
             throw new CustomException(MemberErrorCode.NICKNAME_ALREADY_EXISTS);
         }
     }
@@ -61,9 +61,9 @@ public class MemberService {
         String content = memberCheckRequest.getContent();
 
         if("nickname".equals(type)){
-            return memberRepository.existsByNickname(content);
+            return memberRepository.existsByNicknameAndMemberStatus(content, MemberStatus.ACTIVITY);
         }else if("email".equals(type)){
-            return memberRepository.existsByEmail(content);
+            return memberRepository.existsByEmailAndMemberStatus(content, MemberStatus.ACTIVITY);
         }else {
             throw new CustomException(GlobalErrorCode.BAD_REQUEST);
         }
@@ -126,9 +126,10 @@ public class MemberService {
             .build();
     }
 
-    private void validateDuplicateOnUpdate(String updateEmail, String updateNickname, Long memberId){
-        Member foundMemberByEmail = memberRepository.findByEmail(updateEmail).orElse(null);
-        Member foundMemberByNickname = memberRepository.findByNickname(updateNickname).orElse(null);
+    private void validateDuplicateOnUpdate(String updateEmail, String updateNickname,
+        Long memberId) {
+        Member foundMemberByEmail = memberRepository.findByEmailAndMemberStatus(updateEmail, MemberStatus.ACTIVITY).orElse(null);
+        Member foundMemberByNickname = memberRepository.findByNicknameAndMemberStatus(updateNickname, MemberStatus.ACTIVITY).orElse(null);
 
         if(foundMemberByEmail != null && !foundMemberByEmail.getMemberId().equals(memberId)){
             throw new CustomException(MemberErrorCode.EMAIL_ALREADY_EXISTS);


### PR DESCRIPTION
## 📌 이슈 번호
- #103 

## 👩🏻‍💻 구현 내용
### Problem
- 회원 탈퇴가 soft delete로 처리되어, 탈퇴한 사용자의 이메일/닉네임으로 재가입 하거나 정보 수정이 불가능 문제 발생

### Approach
- `findByEmail`, `findByNickname`  → `findByEmailAndMemberStatus`, `findByNicknameAndMemberStatus`로 변경
- `ACTIVE` 상태의  사용자에 한해서만 검증하도록 수정

### Result
- 탈퇴한 회원의 닉네임/이메일과 동일해도 가입/정보수정 가능