### PR TITLE
fix: 로그인에 사용하는 find 메소드 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/org/candoit/domain/member/repository/MemberRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmail(String email);
     Optional<Member> findByEmailAndMemberStatus(String email, MemberStatus memberStatus);
     Optional<Member> findByNicknameAndMemberStatus(String nickname, MemberStatus memberStatus);
     boolean existsByEmailAndMemberStatus(String email, MemberStatus memberStatus);

--- a/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
+++ b/src/main/java/com/org/candoit/global/security/basic/CustomUserDetailsService.java
@@ -20,7 +20,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public CustomUserDetails loadUserByUsername(String userInfo) throws UsernameNotFoundException {
 
-        Member findMember = (userInfo.contains("@"))?memberRepository.findByEmail(userInfo)
+        Member findMember = (userInfo.contains("@"))?memberRepository.findByEmailAndMemberStatus(userInfo, MemberStatus.ACTIVITY)
             .orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER)):
         memberRepository.findById(Long.parseLong(userInfo))
             .orElseThrow(()->new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));


### PR DESCRIPTION
## 📌 이슈 번호
- #107

## 👩🏻‍💻 구현 내용
### Probleam
- 탈퇴한 회원과 동일한 이메일로 로그인 시, 두 개의 결과가 조회되는 문제가 발생.

### Approach
- `findByEmail` → `findByEmailAndMemberStatus`로 변경해 `ACTIVITY` 상태의 회원만 조회

### Result
- 탈퇴 회원과 충돌 없이 정상적으로 로그인 동작