### PR TITLE
feature: 주간별 서브골 진행도 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/subprogress/controller/SubProgressController.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/controller/SubProgressController.java
@@ -1,0 +1,33 @@
+package com.org.candoit.domain.subprogress.controller;
+
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subprogress.dto.SubProgressOverviewResponse;
+import com.org.candoit.domain.subprogress.service.SubProgressService;
+import com.org.candoit.global.annotation.LoginMember;
+import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import com.org.candoit.domain.subprogress.dto.Direction;
+
+@RestController
+@RequiredArgsConstructor
+public class SubProgressController {
+
+    private final SubProgressService subProgressService;
+
+    @GetMapping("/api/main-goals/{mainGoalId}/sub-progress")
+    public ResponseEntity<ApiResponse<SubProgressOverviewResponse>> getWeeklySubProgress(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long mainGoalId,
+        @RequestParam LocalDate date, @RequestParam Direction direction) {
+        SubProgressOverviewResponse result = subProgressService.getProgressWithoutSubGoal(
+            loginMember, mainGoalId, date, direction);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/Direction.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/Direction.java
@@ -1,0 +1,5 @@
+package com.org.candoit.domain.subprogress.dto;
+
+public enum Direction {
+    PREV, CURRENT, NEXT;
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/SubProgressCalDto.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/SubProgressCalDto.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class SubProgressCalDto {
+    private Long subGoalId;
     private Long dailyActionId;
     private Integer targetNum;
-    private Integer progressCount;
+    private Long progressCount;
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressQueryRepository.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressQueryRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface SubProgressQueryRepository {
 
-    List<SubProgressCalDto> aggregate(Long subGoalId, LocalDate start, LocalDate end);
+    List<SubProgressCalDto> aggregate(List<Long> subGoalIds, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/service/SubProgressService.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/service/SubProgressService.java
@@ -1,0 +1,102 @@
+package com.org.candoit.domain.subprogress.service;
+
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.DetailSubProgressResponse;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import com.org.candoit.domain.subprogress.dto.Direction;
+import com.org.candoit.domain.subprogress.dto.SubProgressCalDto;
+import com.org.candoit.domain.subprogress.dto.SubProgressOverviewResponse;
+import com.org.candoit.domain.subprogress.repository.SubProgressQueryRepository;
+import com.org.candoit.global.util.DateTimeUtil;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SubProgressService {
+
+    private final SubProgressQueryRepository subProgressQueryRepository;
+    private final SubGoalCustomRepository subGoalCustomRepository;
+
+    public SubProgressOverviewResponse getProgressWithoutSubGoal(Member loginMember,
+        Long mainGoalId,
+        LocalDate date, Direction direction) {
+
+        List<SubGoal> subGoals = subGoalCustomRepository.findByMemberIdAndMainGoalId(
+                loginMember.getMemberId(), mainGoalId).stream()
+            .sorted(Comparator.comparing(SubGoal::getSlotNum))
+            .toList();
+
+        return getProgress(subGoals, date, direction);
+    }
+
+    public SubProgressOverviewResponse getProgress(List<SubGoal> subGoals,
+        LocalDate date, Direction direction) {
+
+        switch (direction){
+            case PREV -> date = date.minusWeeks(1);
+            case NEXT -> date = date.plusWeeks(1);
+            case CURRENT -> {}
+        }
+
+        LocalDate monday = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate sunday = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+
+        List<Long> subGoalIds = subGoals.stream()
+            .map(SubGoal::getSubGoalId)
+            .toList();
+
+        List<SubProgressCalDto> subProgress = subProgressQueryRepository.aggregate(subGoalIds,
+            monday, sunday);
+
+        Map<Long, List<SubProgressCalDto>> grouping = subProgress.stream()
+            .collect(Collectors.groupingBy(SubProgressCalDto::getSubGoalId));
+
+        List<DetailSubProgressResponse> detailSubProgress = subGoals.stream()
+            .map(subGoal -> {
+                List<SubProgressCalDto> list = grouping.getOrDefault(subGoal.getSubGoalId(), List.of());
+                return new DetailSubProgressResponse(subGoal.getSubGoalName(), subGoal.getSlotNum(),
+                    calculateRate(list));
+            }).toList();
+
+        int weekOfMonth = DateTimeUtil.getWeekOfMonth(date);
+
+        return SubProgressOverviewResponse.builder()
+            .startDate(monday)
+            .endDate(sunday)
+            .weekOfMonth(weekOfMonth)
+            .subProgress(detailSubProgress)
+            .build();
+    }
+
+    public int calculateRate(List<SubProgressCalDto> subProgressCalDto) {
+
+        if (subProgressCalDto.isEmpty()) {
+            return 0;
+        }
+
+        int sum = 0;
+        for (SubProgressCalDto sp : subProgressCalDto) {
+            int rate;
+            if (sp.getProgressCount() == 0) {
+                rate = 0;
+            } else if (sp.getProgressCount() >= sp.getTargetNum()) {
+                rate = 100;
+            } else {
+                rate = (int) Math.round((double) sp.getProgressCount() / sp.getTargetNum() * 100.0);
+            }
+            sum += rate;
+        }
+        return sum / subProgressCalDto.size();
+    }
+}

--- a/src/test/java/com/org/candoit/maingoal/service/MainGoalServiceTest.java
+++ b/src/test/java/com/org/candoit/maingoal/service/MainGoalServiceTest.java
@@ -5,22 +5,30 @@ import static org.mockito.Mockito.when;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
+import com.org.candoit.domain.maingoal.dto.MainGoalDetailsResponse;
 import com.org.candoit.domain.maingoal.entity.MainGoal;
 import com.org.candoit.domain.maingoal.entity.MainGoalStatus;
 import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
 import com.org.candoit.domain.maingoal.repository.MainGoalRepository;
 import com.org.candoit.domain.maingoal.service.MainGoalService;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.DetailSubProgressResponse;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
 import com.org.candoit.domain.subgoal.repository.SubGoalRepository;
+import com.org.candoit.domain.subprogress.dto.Direction;
 import com.org.candoit.domain.subprogress.dto.SubProgressCalDto;
+import com.org.candoit.domain.subprogress.dto.SubProgressOverviewResponse;
 import com.org.candoit.domain.subprogress.repository.SubProgressQueryRepository;
 
+import com.org.candoit.domain.subprogress.service.SubProgressService;
+import com.org.candoit.global.util.DateTimeUtil;
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -37,15 +45,25 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class MainGoalServiceTest {
 
-    @Mock MainGoalRepository mainGoalRepository;
-    @Mock MainGoalCustomRepository mainGoalCustomRepository;
-    @Mock SubGoalRepository subGoalRepository;
-    @Mock DailyActionRepository dailyActionRepository;
-    @Mock SubGoalCustomRepository subGoalCustomRepository;
-    @Mock SubProgressQueryRepository subProgressQueryRepository;
+    @Mock
+    MainGoalRepository mainGoalRepository;
+    @Mock
+    MainGoalCustomRepository mainGoalCustomRepository;
+    @Mock
+    SubGoalRepository subGoalRepository;
+    @Mock
+    DailyActionRepository dailyActionRepository;
+    @Mock
+    SubGoalCustomRepository subGoalCustomRepository;
+    @Mock
+    SubProgressQueryRepository subProgressQueryRepository;
+    @Mock
+    SubProgressService subProgressService;
 
-    @Mock Clock clock;
-    @InjectMocks MainGoalService mainGoalService;
+    @Mock
+    Clock clock;
+    @InjectMocks
+    MainGoalService mainGoalService;
 
     Member member;
 
@@ -68,49 +86,67 @@ class MainGoalServiceTest {
             .build();
 
         List<SubGoal> subGoals = new ArrayList<>();
-        for (long i = 0; i < 5; i++) {
+        for (int i = 0; i < 5; i++) {
             subGoals.add(SubGoal.builder()
-                .subGoalId(i + 1)
+                .subGoalId((long) (i + 1))
                 .subGoalName("서브골 " + (i + 1))
                 .mainGoal(savedMainGoal)
-                .slotNum((int) i + 1)
+                .slotNum(i + 1)
                 .isStore(false)
                 .build());
         }
 
         when(mainGoalCustomRepository.findByMainGoalIdAndMemberId(anyLong(), anyLong()))
             .thenReturn(Optional.of(savedMainGoal));
+
         when(subGoalCustomRepository.findByMainGoalId(anyLong()))
             .thenReturn(subGoals);
 
+        // 고정 시간
         when(clock.getZone()).thenReturn(ZoneId.of("Asia/Seoul"));
         when(clock.instant()).thenReturn(Instant.parse("2025-08-20T10:00:00Z"));
+        LocalDate now = LocalDate.ofInstant(clock.instant(), clock.getZone());
 
-        List<SubProgressCalDto> agg = List.of(
-            new SubProgressCalDto(101L, 5, 2),
-            new SubProgressCalDto(102L, 5, 5)
+        LocalDate expectedMonday = now.with(
+            TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)); // 2025-08-18
+        LocalDate expectedSunday = now.with(
+            TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));     // 2025-08-24
+        int expectedWeekOfMonth = DateTimeUtil.getWeekOfMonth(now);
+
+        List<DetailSubProgressResponse> details = List.of(
+            new DetailSubProgressResponse("서브골 1", 1, 70),
+            new DetailSubProgressResponse("서브골 2", 2, 10),
+            new DetailSubProgressResponse("서브골 3", 3, 20),
+            new DetailSubProgressResponse("서브골 4", 4, 30),
+            new DetailSubProgressResponse("서브골 5", 5, 40)
         );
-        subGoals.forEach(sg -> {
-            when(subProgressQueryRepository.aggregate(eq(sg.getSubGoalId()), any(LocalDate.class), any(LocalDate.class)))
-                .thenReturn(agg);
-        });
 
-        // when
-        var res = mainGoalService.getMainGoalDetails(member, /*mainGoalId*/ 999L);
+        SubProgressOverviewResponse subProgressOverviewResponse = SubProgressOverviewResponse.builder()
+            .startDate(expectedMonday)
+            .endDate(expectedSunday)
+            .weekOfMonth(expectedWeekOfMonth)
+            .subProgress(details)
+            .build();
+
+        when(subProgressService.getProgress(anyList(), any(LocalDate.class), eq(Direction.CURRENT)))
+            .thenReturn(subProgressOverviewResponse);
+
+        MainGoalDetailsResponse result = mainGoalService.getMainGoalDetails(member, 1l);
 
         // then
-        assertNotNull(res);
-        assertEquals("test용 메인골", res.getMainGoal().getName());
-        assertEquals(MainGoalStatus.ACTIVITY, res.getMainGoal().getStatus());
+        assertNotNull(result);
+        assertEquals("test용 메인골", result.getMainGoal().getName());
+        assertEquals(MainGoalStatus.ACTIVITY, result.getMainGoal().getStatus());
 
-        assertEquals(5, res.getSubGoals().size());
-        assertEquals("서브골 1", res.getSubGoals().get(0).getName());
-        assertEquals(1, res.getSubGoals().get(0).getSlotNum());
+        assertEquals(5, result.getSubGoals().size());
+        assertEquals("서브골 1", result.getSubGoals().get(0).getName());
+        assertEquals(1, result.getSubGoals().get(0).getSlotNum());
 
-        assertEquals(LocalDate.of(2025, 8, 18), res.getProgress().getStartDate());
-        assertEquals(LocalDate.of(2025, 8, 24), res.getProgress().getEndDate());
+        assertEquals(LocalDate.of(2025, 8, 18), result.getProgress().getStartDate());
+        assertEquals(LocalDate.of(2025, 8, 24), result.getProgress().getEndDate());
 
-        assertEquals(5, res.getProgress().getSubProgress().size());
-        assertEquals(70, res.getProgress().getSubProgress().get(0).getRate());
+        assertEquals(5, result.getProgress().getSubProgress().size());
+        assertEquals(70, result.getProgress().getSubProgress().get(0).getRate());
     }
+
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #102 

## 👩🏻‍💻 구현 내용

### Problem
- 메인골 상세 조회 시 서브골 진행도를 구하는 과정에서 N+1 쿼리 발생
- 메인골 상세/주간 진행도 API에 진행도 계산 로직이 중복

### Approach
1) Service
- `date`와 `direction`을 기반으로 조회 범위를 계산
- 진행도 계산 로직을 별도 메소드로 분리
- 메인골 상세 조회 시 `subProgressService.getProgress()`를 호출해 공통화

2) Repository
- 기존: mainGoalId로 SubGoal 리스트를 조회한 뒤 각 SubGoal마다 쿼리 실행 → N+1 문제
- 개선: SubGoalId 리스트를 한 번에 조회해 집계 쿼리 실행
- `LEFT JOIN` + `COUNT(DISTINCT checked_date)`로 진행도 계산

### Result
- 쿼리 횟수 N+1 → 2회로 최적화
- 메인골 상세/주간 진행도 API의 중복 로직 제거
- Service 간 책임 분리로 코드 가독성/유지보수성 향상

### Learned
- QueryDSL에서 group by 시 targetNum까지 group by에 포함시켜야 에러가 나지 않는다는 점 확인
- 테스트(mock)에서 인자 매칭 문제로 `PotentialStubbingProblem` 발생 → `anyList()`, `any(LocalDate.class)`, `eq(Direction.CURRENT)` 조합으로 해결
