### PR TITLE
feature: 서브골 단위 체크현황 조회 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/subprogress/controller/SubProgressController.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/controller/SubProgressController.java
@@ -1,12 +1,15 @@
 package com.org.candoit.domain.subprogress.controller;
 
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subprogress.dto.CheckedSubProgressResponse;
+import com.org.candoit.domain.subprogress.dto.DateUnit;
 import com.org.candoit.domain.subprogress.dto.SubProgressOverviewResponse;
 import com.org.candoit.domain.subprogress.service.SubProgressService;
 import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,6 +31,19 @@ public class SubProgressController {
         @RequestParam LocalDate date, @RequestParam Direction direction) {
         SubProgressOverviewResponse result = subProgressService.getProgressWithoutSubGoal(
             loginMember, mainGoalId, date, direction);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/api/main-goals/{mainGoalId}/sub-progress/checked")
+    public ResponseEntity<ApiResponse<List<CheckedSubProgressResponse>>> getCheckedSubProgress(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long mainGoalId,
+        @RequestParam LocalDate date, @RequestParam Direction direction,
+        @RequestParam DateUnit unit
+    ) {
+        List<CheckedSubProgressResponse> result = subProgressService.getCheckedProgress(
+            loginMember, mainGoalId, date, direction, unit
+        );
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/CheckedSubProgressResponse.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/CheckedSubProgressResponse.java
@@ -1,0 +1,15 @@
+package com.org.candoit.domain.subprogress.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CheckedSubProgressResponse {
+    LocalDate checkedDate;
+    List<Integer> slotNum;
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/DateSlotRow.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/DateSlotRow.java
@@ -1,0 +1,5 @@
+package com.org.candoit.domain.subprogress.dto;
+
+import java.time.LocalDate;
+
+public record DateSlotRow(LocalDate checkedDate, Integer slotNum) {}

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/DateUnit.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/DateUnit.java
@@ -1,0 +1,5 @@
+package com.org.candoit.domain.subprogress.dto;
+
+public enum DateUnit {
+    WEEK, MONTH;
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressQueryRepository.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressQueryRepository.java
@@ -1,5 +1,7 @@
 package com.org.candoit.domain.subprogress.repository;
 
+import com.org.candoit.domain.subprogress.dto.CheckedSubProgressResponse;
+import com.org.candoit.domain.subprogress.dto.DateSlotRow;
 import com.org.candoit.domain.subprogress.dto.SubProgressCalDto;
 import java.time.LocalDate;
 import java.util.List;
@@ -7,4 +9,5 @@ import java.util.List;
 public interface SubProgressQueryRepository {
 
     List<SubProgressCalDto> aggregate(List<Long> subGoalIds, LocalDate start, LocalDate end);
+    List<DateSlotRow> getCheckedSubProgressByDate(List<Long> subGoalIds, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressQueryRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/repository/SubProgressQueryRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.org.candoit.domain.subprogress.repository;
 
 import static com.org.candoit.domain.dailyaction.entity.QDailyAction.dailyAction;
 import static com.org.candoit.domain.dailyprogress.entity.QDailyProgress.dailyProgress;
+import static com.org.candoit.domain.subgoal.entity.QSubGoal.subGoal;
 
+import com.org.candoit.domain.subprogress.dto.DateSlotRow;
 import com.org.candoit.domain.subprogress.dto.SubProgressCalDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -46,5 +48,26 @@ public class SubProgressQueryRepositoryImpl implements SubProgressQueryRepositor
             .fetch();
 
         return subProgressCalDto;
+    }
+
+    @Override
+    public List<DateSlotRow> getCheckedSubProgressByDate(List<Long> subGoalIds,
+        LocalDate start, LocalDate end) {
+        return jpaQueryFactory.select(
+            Projections.constructor(
+                DateSlotRow.class,
+                dailyProgress.checkedDate,
+                subGoal.slotNum
+            ))
+            .from(dailyProgress)
+            .join(dailyProgress.dailyAction, dailyAction)
+            .join(dailyAction.subGoal, subGoal)
+            .where(
+                subGoal.subGoalId.in(subGoalIds),
+                dailyProgress.checkedDate.between(start, end)
+            )
+            .distinct()
+            .orderBy(dailyProgress.checkedDate.asc(), subGoal.slotNum.asc())
+            .fetch();
     }
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/service/SubProgressService.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/service/SubProgressService.java
@@ -4,15 +4,20 @@ import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.subgoal.dto.DetailSubProgressResponse;
 import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import com.org.candoit.domain.subprogress.dto.CheckedSubProgressResponse;
+import com.org.candoit.domain.subprogress.dto.DateSlotRow;
+import com.org.candoit.domain.subprogress.dto.DateUnit;
 import com.org.candoit.domain.subprogress.dto.Direction;
 import com.org.candoit.domain.subprogress.dto.SubProgressCalDto;
 import com.org.candoit.domain.subprogress.dto.SubProgressOverviewResponse;
 import com.org.candoit.domain.subprogress.repository.SubProgressQueryRepository;
 import com.org.candoit.global.util.DateTimeUtil;
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,6 +32,7 @@ public class SubProgressService {
 
     private final SubProgressQueryRepository subProgressQueryRepository;
     private final SubGoalCustomRepository subGoalCustomRepository;
+    private final Clock clock;
 
     public SubProgressOverviewResponse getProgressWithoutSubGoal(Member loginMember,
         Long mainGoalId,
@@ -43,10 +49,11 @@ public class SubProgressService {
     public SubProgressOverviewResponse getProgress(List<SubGoal> subGoals,
         LocalDate date, Direction direction) {
 
-        switch (direction){
+        switch (direction) {
             case PREV -> date = date.minusWeeks(1);
             case NEXT -> date = date.plusWeeks(1);
-            case CURRENT -> {}
+            case CURRENT -> {
+            }
         }
 
         LocalDate monday = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
@@ -64,7 +71,8 @@ public class SubProgressService {
 
         List<DetailSubProgressResponse> detailSubProgress = subGoals.stream()
             .map(subGoal -> {
-                List<SubProgressCalDto> list = grouping.getOrDefault(subGoal.getSubGoalId(), List.of());
+                List<SubProgressCalDto> list = grouping.getOrDefault(subGoal.getSubGoalId(),
+                    List.of());
                 return new DetailSubProgressResponse(subGoal.getSubGoalName(), subGoal.getSlotNum(),
                     calculateRate(list));
             }).toList();
@@ -98,5 +106,56 @@ public class SubProgressService {
             sum += rate;
         }
         return sum / subProgressCalDto.size();
+    }
+
+    public List<CheckedSubProgressResponse> getCheckedProgress(Member loginMember, Long mainGoalId,
+        LocalDate date, Direction direction, DateUnit unit) {
+
+        List<SubGoal> subGoals = subGoalCustomRepository.findByMemberIdAndMainGoalId(
+                loginMember.getMemberId(), mainGoalId).stream()
+            .sorted(Comparator.comparing(SubGoal::getSlotNum))
+            .toList();
+
+        List<Long> subGoalIds = subGoals.stream()
+            .map(SubGoal::getSubGoalId)
+            .toList();
+
+        LocalDate start = date;
+        LocalDate end = date;
+
+        if (unit == DateUnit.MONTH) {
+            switch (direction) {
+                case PREV -> date = date.minusMonths(1);
+                case NEXT -> date = date.plusMonths(1);
+            }
+            start = date.with(TemporalAdjusters.firstDayOfMonth());
+            end = date.with(TemporalAdjusters.lastDayOfMonth());
+        } else if (unit == DateUnit.WEEK) {
+            switch (direction) {
+                case PREV -> date = date.minusMonths(1);
+                case NEXT -> date = date.plusMonths(1);
+            }
+            start = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            end = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        }
+
+        List<DateSlotRow> rows = subProgressQueryRepository.getCheckedSubProgressByDate(subGoalIds,
+            start, end);
+
+        Map<LocalDate, List<Integer>> grouping = rows.stream()
+            .collect(Collectors.groupingBy(
+                DateSlotRow::checkedDate,
+                LinkedHashMap::new,
+                Collectors.mapping(DateSlotRow::slotNum, Collectors.toList())
+
+            ));
+
+        grouping.replaceAll((d, list) ->
+            list.stream().distinct().sorted().toList());
+
+        return grouping.entrySet().stream()
+            .sorted(Map.Entry.comparingByKey())
+            .map(e -> new CheckedSubProgressResponse(e.getKey(), e.getValue()))
+            .toList();
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #110 
## 👩🏻‍💻 구현 내용
### Problem
- 홈 화면에서 부분 조회가 가능한 서브골 스트릭 조회 api가 필요
### Approach
**① Repository: 조건 조회**
- subGoalId, start ~ end 기간 조건으로 checked_date, slot_num 컬럼 조회

**② Service: 날짜 기준 그룹핑**
- Map<LocalDate, List<Integer>>로 그룹핑 후 응답 DTO로 변환