### PR TITLE
feature: 홈 api 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/home/controller/HomeController.java
+++ b/src/main/java/com/org/candoit/domain/home/controller/HomeController.java
@@ -1,0 +1,31 @@
+package com.org.candoit.domain.home.controller;
+
+import com.org.candoit.domain.home.dto.HomeOverallResponse;
+import com.org.candoit.domain.home.service.HomeService;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.global.annotation.LoginMember;
+import com.org.candoit.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Parameter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeController {
+
+    private final HomeService homeService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<HomeOverallResponse>> getHome(
+        @Parameter(hidden = true) @LoginMember Member member,
+        @RequestParam(required = false) Long mainGoalId
+    ) {
+        HomeOverallResponse result = homeService.getHomeOverall(member, mainGoalId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+}

--- a/src/main/java/com/org/candoit/domain/home/dto/HomeOverallResponse.java
+++ b/src/main/java/com/org/candoit/domain/home/dto/HomeOverallResponse.java
@@ -1,0 +1,17 @@
+package com.org.candoit.domain.home.dto;
+
+import com.org.candoit.domain.maingoal.dto.MainGoalDataForHomeResponse;
+import com.org.candoit.domain.subgoal.dto.SubGoalDataForHomeResponse;
+import com.org.candoit.domain.subprogress.dto.CheckedSubProgressResponse;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class HomeOverallResponse {
+
+    private MainGoalDataForHomeResponse mainGoal;
+    private List<SubGoalDataForHomeResponse> subGoals;
+    private List<CheckedSubProgressResponse> progress;
+}

--- a/src/main/java/com/org/candoit/domain/home/service/HomeService.java
+++ b/src/main/java/com/org/candoit/domain/home/service/HomeService.java
@@ -1,0 +1,110 @@
+package com.org.candoit.domain.home.service;
+
+import com.org.candoit.domain.home.dto.HomeOverallResponse;
+import com.org.candoit.domain.maingoal.dto.MainGoalDataForHomeResponse;
+import com.org.candoit.domain.maingoal.entity.MainGoal;
+import com.org.candoit.domain.maingoal.exception.MainGoalErrorCode;
+import com.org.candoit.domain.maingoal.repository.MainGoalCustomRepository;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.dto.DetailSubProgressResponse;
+import com.org.candoit.domain.subgoal.dto.SubGoalDataForHomeResponse;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
+import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import com.org.candoit.domain.subprogress.dto.CheckedSubProgressResponse;
+import com.org.candoit.domain.subprogress.dto.DateUnit;
+import com.org.candoit.domain.subprogress.dto.Direction;
+import com.org.candoit.domain.subprogress.service.SubProgressService;
+import com.org.candoit.global.response.CustomException;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class HomeService {
+
+    private static final Logger log = LoggerFactory.getLogger(HomeService.class);
+    private final MainGoalCustomRepository mainGoalCustomRepository;
+    private final SubGoalCustomRepository subGoalCustomRepository;
+    private final Clock clock;
+    private final SubProgressService subProgressService;
+
+    public HomeOverallResponse getHomeOverall(Member member, Long mainGoalId) {
+
+        // 조회하려는 메인골 정하는 로직
+        MainGoal mainGoal = getMainGoal(member.getMemberId(), mainGoalId);
+
+        LocalDate today = LocalDate.now(clock);
+
+        List<SubGoal> subGoals = subGoalCustomRepository
+            .findByMainGoalId(mainGoal.getMainGoalId())
+            .stream()
+            .sorted(Comparator.comparing(SubGoal::getSlotNum))
+            .toList();
+
+        List<SubGoalDataForHomeResponse> subGoalResponse =
+            subGoals.isEmpty() ? List.of() : subGoals.stream().map(
+                    subGoal -> SubGoalDataForHomeResponse.builder()
+                        .id(subGoal.getSubGoalId())
+                        .name(subGoal.getSubGoalName())
+                        .slotNum(subGoal.getSlotNum())
+                        .achievement(subGoal.getIsStore())
+                        .build())
+                .toList();
+
+        List<DetailSubProgressResponse> lastChecked = subProgressService.getProgress(subGoals,
+            today, Direction.PREV).getSubProgress();
+
+        List<DetailSubProgressResponse> thisChecked = subProgressService.getProgress(subGoals,
+            today, Direction.CURRENT).getSubProgress();
+
+        MainGoalDataForHomeResponse mainGoalResponse = MainGoalDataForHomeResponse.builder()
+            .id(mainGoal.getMainGoalId())
+            .name(mainGoal.getMainGoalName())
+            .lastAchievement(getRateForMainGoal(lastChecked))
+            .thisAchievement(getRateForMainGoal(thisChecked))
+            .build();
+
+        List<CheckedSubProgressResponse> progress = subProgressService.getCheckedProgress(member,
+            mainGoal.getMainGoalId(), today, Direction.CURRENT, DateUnit.WEEK);
+
+        return HomeOverallResponse.builder()
+            .mainGoal(mainGoalResponse)
+            .subGoals(subGoalResponse)
+            .progress(progress)
+            .build();
+    }
+
+    private MainGoal getMainGoal(Long memberId, Long mainGoalId) {
+
+        if (mainGoalId != null) {
+            return mainGoalCustomRepository.findByMainGoalIdAndMemberId(mainGoalId, memberId)
+                .orElseThrow(() -> new CustomException(
+                    MainGoalErrorCode.NOT_FOUND_MAIN_GOAL));
+        }
+        return mainGoalCustomRepository
+            .findRepresentativeMainGoalByMemberId(memberId)
+            .orElseGet(() -> mainGoalCustomRepository.findOldestByMemberId(memberId)
+                .orElseThrow(() -> new CustomException(MainGoalErrorCode.NOT_FOUND_MAIN_GOAL)));
+    }
+
+    private int getRateForMainGoal(List<DetailSubProgressResponse> checkState) {
+        if (checkState.isEmpty()) {
+            return 0;
+        }
+        int sum = 0;
+        int count = 0;
+
+        for (DetailSubProgressResponse detailSubProgressResponse : checkState) {
+
+            sum += detailSubProgressResponse.getRate();
+            count++;
+        }
+        return (int) Math.round(sum * 1.0 / count);
+    }
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalDataForHomeResponse.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/dto/MainGoalDataForHomeResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.maingoal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MainGoalDataForHomeResponse {
+
+    private Long id;
+    private String name;
+    private Integer lastAchievement;
+    private Integer thisAchievement;
+}

--- a/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/entity/MainGoal.java
@@ -42,10 +42,6 @@ public class MainGoal extends BaseTimeEntity {
     @Builder.Default
     private MainGoalStatus mainGoalStatus = MainGoalStatus.ACTIVITY;
 
-    private Integer lastAchievementRate;
-
-    private Integer thisAchievementRate;
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     @OnDelete(action = OnDeleteAction.CASCADE)

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepository.java
@@ -11,4 +11,5 @@ public interface MainGoalCustomRepository {
     Optional<MainGoal> findRepresentativeMainGoalByMemberId(Long memberId);
     List<MainGoal> findByMemberIdAndStatus(Long memberId, MainGoalStatus status);
     List<MainGoal> findByMemberId(Long memberId);
+    Optional<MainGoal> findOldestByMemberId(Long memberId);
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
@@ -53,8 +53,20 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             .fetch();
     }
 
+    @Override
+    public Optional<MainGoal> findOldestByMemberId(Long memberId) {
+        return Optional.ofNullable(jpaQueryFactory.select(mainGoal)
+            .from(mainGoal)
+            .where(mainGoal.member.memberId.eq(memberId)
+                .and(mainGoal.mainGoalStatus.eq(MainGoalStatus.ACTIVITY)))
+            .orderBy(mainGoal.mainGoalId.asc())
+            .fetchFirst());
+    }
+
     private BooleanExpression checkStatus(MainGoalStatus status) {
-        if(status == null) return null;
+        if (status == null) {
+            return null;
+        }
         return mainGoal.mainGoalStatus.eq(status);
     }
 }

--- a/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/service/MainGoalService.java
@@ -62,8 +62,6 @@ public class MainGoalService {
             .member(member)
             .mainGoalName(request.getName())
             .mainGoalStatus(MainGoalStatus.ACTIVITY)
-            .thisAchievementRate(0)
-            .lastAchievementRate(0)
             .isRepresentative(Boolean.FALSE)
             .build();
 

--- a/src/main/java/com/org/candoit/domain/subgoal/dto/SubGoalDataForHomeResponse.java
+++ b/src/main/java/com/org/candoit/domain/subgoal/dto/SubGoalDataForHomeResponse.java
@@ -1,0 +1,14 @@
+package com.org.candoit.domain.subgoal.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SubGoalDataForHomeResponse {
+
+    private Long id;
+    private String name;
+    private Integer slotNum;
+    private Boolean achievement;
+}

--- a/src/main/java/com/org/candoit/domain/subprogress/service/SubProgressService.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/service/SubProgressService.java
@@ -132,8 +132,8 @@ public class SubProgressService {
             end = date.with(TemporalAdjusters.lastDayOfMonth());
         } else if (unit == DateUnit.WEEK) {
             switch (direction) {
-                case PREV -> date = date.minusMonths(1);
-                case NEXT -> date = date.plusMonths(1);
+                case PREV -> date = date.minusWeeks(1);
+                case NEXT -> date = date.plusWeeks(1);
             }
             start = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
             end = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));

--- a/src/main/resources/db/migration/V9__drop_main_goal_achievement_fields.sql
+++ b/src/main/resources/db/migration/V9__drop_main_goal_achievement_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE main_goal
+DROP COLUMN last_achievement_rate,
+DROP COLUMN this_achievement_rate;


### PR DESCRIPTION
## 📌 이슈 번호
- #112 
## 👩🏻‍💻 구현 내용
### Problem
- 홈 조회 api 필요
- subProgressService의 getCheckedProgress()에서 쿼리 스트링으로 week가 넘어온 경우에도 month로 계산되고 있음.
- mainGoal에 `lastAchievement`, `thisAchievemnet` 제거

### Approach
**① 대표 메인골이 없는 경우, 가장 처음 생성한 메인골을 응답**
- qeurydsl을 사용해 `findOldestByMemberId` 메소드를 작성
- MainGoalStatus가 `ACTIVITY`상태의 메인골만 조회

**② 날짜 계산 수정**
- subProgressService의 getCheckedProgress()메소드에서 `DateUnit.WEEK`인 경우, `minusMonths(1), plusMonths(1)➜minusWeeks(1), plusWeeks(1)`로 변경

**③ 엔티티 수정과 DDL 스크립트를 작성해 필드 제거**
- 기존에는 저번주 달성률과 이번주 달성률을 DB에 저장해 매주 일요일 23:59마다 갱신할 수 있도록 하는 것을 계획함.
- 그러나, 갱신 과정에서 오류가 발생할 수 있다고 생각함.
- 또한, 사용자가 DailyAction 스트릭을 체크할 때마다 이번 주 달성률이 계산되어야 하기 때문에 오히려 조회할 때마다 계산하는 것이 **데이터 정합성 측면에서 좋을 것이라고 판단**하여 제거함.
 
### Result
- 홈 조회 API가 정상 동작
- `unit=week` 요청 시 주 단위 계산이 올바르게 적용됨
- 불필요 필드 제거로 정합성/유지보수성 향상, 마이그레이션 적용 후 정상 응답 확인