### PR TITLE
feature: 서브골 데일리프로그레스 조회 구현

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
@@ -51,7 +51,7 @@ public class DailyProgressController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @GetMapping("/sub-goals/{subGoalId}/daily-progress/checked")
+    @GetMapping("/sub-goals/{subGoalId}/daily-progress/calendar")
     public ResponseEntity<ApiResponse<DailyProgressResponse>> getDailyProgressCalendar(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId, @RequestParam LocalDate date,

--- a/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
@@ -1,12 +1,16 @@
 package com.org.candoit.domain.dailyprogress.controller;
 
 import com.org.candoit.domain.dailyaction.dto.ActionDates;
+import com.org.candoit.domain.dailyprogress.dto.DailyProgressResponse;
 import com.org.candoit.domain.dailyprogress.dto.DetailProgressResponse;
 import com.org.candoit.domain.dailyprogress.service.DailyProgressService;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subprogress.dto.DateUnit;
+import com.org.candoit.domain.subprogress.dto.Direction;
 import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -25,7 +30,7 @@ public class DailyProgressController {
 
     private final DailyProgressService dailyProgressService;
 
-    @PutMapping ("/sub-goals/{subGoalId}/daily-progress")
+    @PutMapping("/sub-goals/{subGoalId}/daily-progress")
     public ResponseEntity<ApiResponse<List<DetailProgressResponse>>> checkedDate(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId,
@@ -43,6 +48,17 @@ public class DailyProgressController {
     ) {
         List<DetailProgressResponse> result = dailyProgressService.getDailyProgress(loginMember,
             subGoalId);
+        return ResponseEntity.ok(ApiResponse.success(result));
+    }
+
+    @GetMapping("/sub-goals/{subGoalId}/daily-progress/checked")
+    public ResponseEntity<ApiResponse<DailyProgressResponse>> getDailyProgressCalendar(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @PathVariable Long subGoalId, @RequestParam LocalDate date,
+        @RequestParam Direction direction, @RequestParam DateUnit unit
+    ) {
+        DailyProgressResponse result = dailyProgressService.getCalendarWithoutDailyActions(
+            loginMember, subGoalId, date, direction, unit);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/service/DailyProgressService.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/service/DailyProgressService.java
@@ -1,15 +1,20 @@
 package com.org.candoit.domain.dailyprogress.service;
 
+import com.org.candoit.domain.dailyaction.dto.ActionDates;
+import com.org.candoit.domain.dailyaction.dto.DailyActionInfoWithAttainmentResponse;
 import com.org.candoit.domain.dailyaction.repository.DailyActionCustomRepository;
 import com.org.candoit.domain.dailyaction.repository.DailyActionRepository;
-import com.org.candoit.domain.dailyaction.dto.ActionDates;
+import com.org.candoit.domain.dailyprogress.dto.DailyProgressResponse;
 import com.org.candoit.domain.dailyprogress.dto.DetailProgressResponse;
 import com.org.candoit.domain.dailyprogress.entity.DailyProgress;
 import com.org.candoit.domain.dailyprogress.repository.DailyProgressCustomRepository;
 import com.org.candoit.domain.dailyprogress.repository.DailyProgressRepository;
 import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.subgoal.entity.SubGoal;
 import com.org.candoit.domain.subgoal.exception.SubGoalErrorCode;
 import com.org.candoit.domain.subgoal.repository.SubGoalCustomRepository;
+import com.org.candoit.domain.subprogress.dto.DateUnit;
+import com.org.candoit.domain.subprogress.dto.Direction;
 import com.org.candoit.global.response.CustomException;
 import java.time.Clock;
 import java.time.DayOfWeek;
@@ -44,27 +49,82 @@ public class DailyProgressService {
         dailyProgressCustomRepository.deleteBySubGoalIdAndDate(subGoalId, startDay, endDay);
 
         List<DailyProgress> progresses = checkDailyProgressRequest.stream()
-                .flatMap(req ->
-                    req.getDates().stream()
-                        .map(date -> DailyProgress.builder()
-                            .dailyAction(dailyActionRepository.getReferenceById(req.getDailyActionId()))
-                            .checkedDate(date)
-                            .build())
-                    ).toList();
+            .flatMap(req ->
+                req.getDates().stream()
+                    .map(date -> DailyProgress.builder()
+                        .dailyAction(dailyActionRepository.getReferenceById(req.getDailyActionId()))
+                        .checkedDate(date)
+                        .build())
+            ).toList();
 
         dailyProgressRepository.saveAll(progresses);
 
         return getDailyProgress(loginMember, subGoalId);
     }
 
-    public List<DetailProgressResponse> getDailyProgress(Member loginMember, Long subGoalId){
+    public List<DetailProgressResponse> getDailyProgress(Member loginMember, Long subGoalId) {
         LocalDate now = LocalDate.now(clock);
         LocalDate startDay = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         LocalDate endDay = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
 
-        subGoalCustomRepository.findByMemberIdAndSubGoalId(loginMember.getMemberId(), subGoalId).orElseThrow(()-> new CustomException(
-            SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+        subGoalCustomRepository.findByMemberIdAndSubGoalId(loginMember.getMemberId(), subGoalId)
+            .orElseThrow(() -> new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
 
         return dailyActionCustomRepository.getActionDates(subGoalId, startDay, endDay);
+    }
+
+    public DailyProgressResponse getCalendarWithoutDailyActions(Member loginMember, Long subGoalId,
+        LocalDate date, Direction direction, DateUnit unit) {
+        SubGoal subGoal = subGoalCustomRepository.findByMemberIdAndSubGoalId(
+                loginMember.getMemberId(), subGoalId)
+            .orElseThrow(() -> new CustomException(SubGoalErrorCode.NOT_FOUND_SUB_GOAL));
+
+        List<DailyActionInfoWithAttainmentResponse> dailyActions = dailyActionCustomRepository.getSimpleDailyActionInfo(
+            subGoal.getSubGoalId());
+
+        return getCalendar(subGoal.getSubGoalId(), date, direction, unit, dailyActions);
+    }
+
+    public DailyProgressResponse getCalendar(Long subGoalId, LocalDate date, Direction direction,
+        DateUnit unit, List<DailyActionInfoWithAttainmentResponse> dailyActions) {
+
+        LocalDate start = date;
+        LocalDate end = date;
+
+        if (unit == DateUnit.MONTH) {
+            switch (direction) {
+                case PREV -> date = date.minusMonths(1);
+                case NEXT -> date = date.plusMonths(1);
+            }
+            start = date.with(TemporalAdjusters.firstDayOfMonth());
+            end = date.with(TemporalAdjusters.lastDayOfMonth());
+        } else if (unit == DateUnit.WEEK) {
+            switch (direction) {
+                case PREV -> date = date.minusWeeks(1);
+                case NEXT -> date = date.plusWeeks(1);
+            }
+            start = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+            end = date.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY));
+        }
+
+        DailyProgressResponse dailyProgressResponse;
+
+        // 데일리 액션이 없는 경우
+        if (dailyActions.isEmpty()) {
+            dailyActions = List.of();
+            dailyProgressResponse = new DailyProgressResponse(start, end, List.of());
+        }
+        // 데일리 액션이 있는 경우
+        else {
+            List<LocalDate> checkedDate = dailyProgressCustomRepository.distinctCheckedDate(
+                subGoalId, start, end);
+
+            dailyProgressResponse = DailyProgressResponse.builder()
+                .startDate(start)
+                .endDate(end)
+                .dailyProgress(checkedDate)
+                .build();
+        }
+        return dailyProgressResponse;
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
- #117
## 👩🏻‍💻 구현 내용
### Problem
- 서브골의 스트릭 조회 api 필요
- 기존 서브골 상세 조회에 있는 로직과 중복됨

### Approach
**① 중복되는 코드를 하나의 메소드로 추출**
  - SubGoalService.class에 있는 코드를 DailyProgressService의 getCalendar로 추출함.

### Result
- 코드 중복 ⬇︎ 응집도 ⬆︎
- 서브골 스트릭 조회가 정상적으로 응답함.
