### PR TITLE
refactor: 쿼리 스트링으로 사용되는 enum 객체에 소문자 지원

### DIFF
--- a/src/main/java/com/org/candoit/domain/subprogress/dto/DateUnit.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/DateUnit.java
@@ -1,5 +1,12 @@
 package com.org.candoit.domain.subprogress.dto;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum DateUnit {
     WEEK, MONTH;
+
+    @JsonValue
+    public String getValue(){
+        return this.getValue().toLowerCase();
+    }
 }

--- a/src/main/java/com/org/candoit/domain/subprogress/dto/Direction.java
+++ b/src/main/java/com/org/candoit/domain/subprogress/dto/Direction.java
@@ -1,5 +1,12 @@
 package com.org.candoit.domain.subprogress.dto;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum Direction {
     PREV, CURRENT, NEXT;
+
+    @JsonValue
+    public String getValue(){
+        return this.getValue().toLowerCase();
+    }
 }

--- a/src/main/java/com/org/candoit/global/response/DateUnitConverter.java
+++ b/src/main/java/com/org/candoit/global/response/DateUnitConverter.java
@@ -1,0 +1,30 @@
+package com.org.candoit.global.response;
+
+import com.org.candoit.domain.subprogress.dto.DateUnit;
+import com.org.candoit.domain.subprogress.dto.Direction;
+import java.util.Arrays;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DateUnitConverter implements Converter<String, DateUnit> {
+
+    @Override
+    public DateUnit convert(String source) {
+        try {
+            return Arrays.stream(DateUnit.values())
+                .filter(v -> v.name().equalsIgnoreCase(source))
+                .findFirst()
+                .orElseThrow();
+        } catch (Exception cause) {
+            throw new ConversionFailedException(
+                TypeDescriptor.valueOf(String.class),
+                TypeDescriptor.valueOf(Direction.class),
+                source,
+                cause
+            );
+        }
+    }
+}

--- a/src/main/java/com/org/candoit/global/response/DirectionConverter.java
+++ b/src/main/java/com/org/candoit/global/response/DirectionConverter.java
@@ -1,0 +1,30 @@
+package com.org.candoit.global.response;
+
+
+import com.org.candoit.domain.subprogress.dto.Direction;
+import java.util.Arrays;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DirectionConverter implements Converter<String, Direction> {
+
+    @Override
+    public Direction convert(String source) {
+        try {
+            return Arrays.stream(Direction.values())
+                .filter(v -> v.name().equalsIgnoreCase(source))
+                .findFirst()
+                .orElseThrow();
+        } catch (Exception cause) {
+            throw new ConversionFailedException(
+                TypeDescriptor.valueOf(String.class),
+                TypeDescriptor.valueOf(Direction.class),
+                source,
+                cause
+            );
+        }
+    }
+}

--- a/src/main/java/com/org/candoit/global/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/org/candoit/global/response/GlobalExceptionHandler.java
@@ -1,13 +1,50 @@
 package com.org.candoit.global.response;
 
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+@Order(Ordered.HIGHEST_PRECEDENCE)
 @RestControllerAdvice(annotations = {RestController.class}, basePackages = {"com.org.candoit.domain"})
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ApiResponse<?> handleMissingParam(MissingServletRequestParameterException ex) {
+        String msg = String.format("'%s' 파라미터가 필요합니다.", ex.getParameterName());
+        return new ApiResponse<>("400", msg, null);
+    }
+
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        Class<?> req = e.getRequiredType();
+
+        if (req != null && req.isEnum()) {
+            List<String> allowed = Arrays.stream(req.getEnumConstants())
+                .map(en -> ((Enum<?>) en).name().toLowerCase())
+                .toList();
+
+            String msg = String.format("'%s' 파라미터는 허용 값 중 하나를 사용하세요. [%s] (입력값: %s)",
+                e.getName(), String.join(", ", allowed), e.getValue());
+
+            ApiResponse<?> body = new ApiResponse<>("400", msg, null);
+            return ResponseEntity.badRequest().body(body);
+        }
+
+        ApiResponse<?> body = new ApiResponse<>("400", "올바른 파라미터를 입력하세요.", null);
+        return ResponseEntity.badRequest().body(body);
+    }
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {


### PR DESCRIPTION
## 📌 이슈 번호
- #119 

## 👩🏻‍💻 구현 내용
### Problem
- enum 타입으로 관리되는 값들이 대문자만 지원

### Approach
**① enum 클래스에 대한 converter 작성**
- 스트림을 순회하며, enum 값이 아닌 경우 예외를 던짐.

**② converter에서 발생하는 예외를 globalExceptionHandler에서 처리**
- globalExceptionHandler에서 해당 예외를 MethodArgumentTypeMismatchException.class로 잡아 처리함
- 해당 예외 상황에서의 응답 시, 클라이언트에서 요청할 수 있는 enum 값 목록을 포함함.

### Result
- 대·소문자/혼합 입력 모두 정상 매핑
- 잘못된 값 입력 시 400과 함께 허용 가능한 enum 목록을 반환