### PR TITLE
fix: 데일리 액션 진행도 조회 응답 필드 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyprogress/dto/DailyProgressRow.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/dto/DailyProgressRow.java
@@ -1,5 +1,0 @@
-package com.org.candoit.domain.dailyprogress.dto;
-
-import java.time.LocalDate;
-
-public record DailyProgressRow(Long dailyActionId, LocalDate checkedDate){}

--- a/src/main/java/com/org/candoit/domain/dailyprogress/dto/DetailProgressResponse.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/dto/DetailProgressResponse.java
@@ -11,5 +11,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DetailProgressResponse {
     private Long dailyActionId;
+    private String title;
+    private String content;
     private List<LocalDate> checkedDate;
 }

--- a/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/repository/DailyProgressCustomRepositoryImpl.java
@@ -3,19 +3,11 @@ package com.org.candoit.domain.dailyprogress.repository;
 import static com.org.candoit.domain.dailyaction.entity.QDailyAction.dailyAction;
 import static com.org.candoit.domain.dailyprogress.entity.QDailyProgress.dailyProgress;
 import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
 
-import com.org.candoit.domain.dailyprogress.dto.DailyProgressRow;
-import com.org.candoit.domain.dailyprogress.dto.DetailProgressResponse;
-import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/resources/db/migration/V10__add_unique_index_daily_progress_daily_action.sql
+++ b/src/main/resources/db/migration/V10__add_unique_index_daily_progress_daily_action.sql
@@ -1,0 +1,4 @@
+CREATE UNIQUE INDEX uq_progress_action_date
+    ON daily_progress(daily_action_id, checked_date);
+
+DROP INDEX idx_progress_action ON daily_progress;


### PR DESCRIPTION
## 📌 이슈 번호
- #122 
## 👩🏻‍💻 구현 내용
### Problem
- 기존 응답은 `dailyActionId`와 `checkedDate`로 구성되어 있었음 .
- 프론트 팀원의 요청으로 dailyAction에 대한 **`title`과 `content`를 포함해 응답**하는 것으로 수정되었음.

### Approach
**① 응답DTO 수정**
- `DetailProgressResponse`에 `title`과 `content` 추가

**② Repository 수정** 
- DailyProgressRow 내부 Record로 수정
  - 기존에는 DailyProgressRow를 class 파일로 관리했으나, 해당 파일이 DailyProgressRepository 내부에서만 사용된다는 점에서 내부 Record로 수정

**③ 기존 인덱스 삭제 및 유니크 인덱스 추가**
- dailyProgress 테이블에서 dailyActionId와 checkedDate의 유니크를 보장하기 위해 유니크 인덱스를 추가
- 기존의 non unique index를 삭제


### Learned
기존 인덱스를 삭제 할 때, 다음과 같은 에러가 발생했습니다.
```bash
Cannot drop index 'idx_progress_action': needed in a foreign key constraint
```
<code>SHOW INDEX FROM [테이블명]</code>
위 커맨드를 사용해 다른 테이블의 인덱스를 조회해본 결과, 참조 관계에서 자식 테이블에 외래키가 INDEX로 작성되는 것을 알게 되었습니다.

기존에 있던 FK의 인덱스를 삭제하며 외래키 제약조건 중 참조 무결성이 깨지며, 해당 에러가 발생한 것으로 유추됩니다.

 따라서, `유니크 인덱스를 추가 ➜ 기존 인덱스 삭제`의 과정으로 문제를 해결했습니다.

