### PR TITLE
fix: corsConfig에 PUT 메소드 추가

### DIFF
--- a/src/main/java/com/org/candoit/global/config/CorsConfig.java
+++ b/src/main/java/com/org/candoit/global/config/CorsConfig.java
@@ -17,7 +17,7 @@ public class CorsConfig {
             "http://localhost:5173","http://localhost:8080",
             "https://handa-plan.vercel.app", "https://api.handa-plan.com"
         ));
-        configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "PUT"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);
         configuration.setMaxAge(3600l);


### PR DESCRIPTION
## 📌 이슈 번호
- #124 

## 👩🏻‍💻 구현 내용
### Problem
- 데일리 프로그레스 날짜 체크 api에서 CORS 에러 발생

### Approach
- 해당 api가 유일한 PUT 메소드로써 기존 `POST ➜ PUT`으로 변경되었다는 점을 파악
- CORS 설정 파일에서 허용 메소드 누락임을 파악하고 CorsConfig 파일을 수정했습니다.
