### PR TITLE
feature: 비밀번호 재설정 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation 'org.flywaydb:flyway-core'
     implementation "com.querydsl:querydsl-jpa:5.1.0:jakarta"
     implementation "com.querydsl:querydsl-core:5.1.0"
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
@@ -63,6 +65,9 @@ dependencies {
 
     // Valid
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // email
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 def querydslDir = "build/generated/querydsl";

--- a/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/org/candoit/domain/auth/controller/AuthController.java
@@ -1,12 +1,17 @@
 package com.org.candoit.domain.auth.controller;
 
+import com.org.candoit.domain.auth.dto.EmailRequest;
 import com.org.candoit.domain.auth.dto.LoginRequest;
 import com.org.candoit.domain.auth.dto.LoginResponse;
 import com.org.candoit.domain.auth.dto.LogoutResponse;
 import com.org.candoit.domain.auth.dto.ReissueResponse;
+import com.org.candoit.domain.auth.dto.VerifyCodeRequest;
 import com.org.candoit.domain.auth.service.AuthService;
+import com.org.candoit.domain.auth.service.EmailService;
+import com.org.candoit.domain.auth.service.EmailVerificationService;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
@@ -22,6 +27,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final AuthService authService;
+    private final EmailService emailService;
+    private final EmailVerificationService emailVerificationService;
 
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Object>> login(@RequestBody LoginRequest loginRequest) {
@@ -51,5 +58,20 @@ public class AuthController {
         ReissueResponse reissueResponse = authService.reissue(accessToken, refreshToken);
         return ResponseEntity.ok().headers(reissueResponse.getHttpHeaders())
             .body(ApiResponse.successWithoutData());
+    }
+
+    @PostMapping("/send-code")
+    public ResponseEntity<ApiResponse<Boolean>> authCode(@RequestBody @Valid EmailRequest emailRequest) {
+
+        emailService.emailVerification(emailRequest);
+        return ResponseEntity.ok()
+            .body(ApiResponse.success(Boolean.TRUE));
+    }
+
+    @PostMapping("/verify-code")
+    public ResponseEntity<ApiResponse<Boolean>> verifyCode(
+        @Valid @RequestBody VerifyCodeRequest verifyCodeRequest) {
+        emailVerificationService.verifyCode(verifyCodeRequest);
+        return ResponseEntity.ok().body(ApiResponse.success(Boolean.TRUE));
     }
 }

--- a/src/main/java/com/org/candoit/domain/auth/dto/EmailRequest.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/EmailRequest.java
@@ -1,0 +1,17 @@
+package com.org.candoit.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class EmailRequest {
+
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일은 필수 입력 사항입니다.")
+    private String email;
+}

--- a/src/main/java/com/org/candoit/domain/auth/dto/VerifyCodeRequest.java
+++ b/src/main/java/com/org/candoit/domain/auth/dto/VerifyCodeRequest.java
@@ -1,0 +1,20 @@
+package com.org.candoit.domain.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class VerifyCodeRequest {
+
+    @Email(message = "이메일 형식에 맞지 않습니다.")
+    @NotBlank(message = "이메일은 필수 입력 사항입니다.")
+    private String email;
+
+    @NotBlank(message = "인증 코드를 입력해주세요.")
+    private String code;
+}

--- a/src/main/java/com/org/candoit/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/org/candoit/domain/auth/exception/AuthErrorCode.java
@@ -10,7 +10,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public enum AuthErrorCode implements ErrorCode {
 
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"14000", "로그인된 사용자가 아닙니다.");
+    NOT_MATCH_AUTH_CODE(HttpStatus.BAD_REQUEST, "14001","인증 코드가 일치하지 않습니다."),
+    INVALID_AUTH_CODE(HttpStatus.UNAUTHORIZED,"14002", "인증 코드가 유효하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"14000", "로그인된 사용자가 아닙니다."),
+    EMAIL_VERIFICATION_REQUIRED(HttpStatus.UNAUTHORIZED, "14003", "이메일 인증이 필요합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/org/candoit/domain/auth/service/EmailSenderService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/EmailSenderService.java
@@ -1,0 +1,73 @@
+package com.org.candoit.domain.auth.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.thymeleaf.context.Context;
+import org.thymeleaf.spring6.SpringTemplateEngine;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailSenderService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JavaMailSender javaMailSender;
+    private final SpringTemplateEngine templateEngine;
+
+    static final String PREFIX = "auth:email:";
+
+    @Async("mailExecutor")
+    public void sendEmail(String email) {
+        log.info("[Thread: {}] sending mail to {}", Thread.currentThread().getName(), email);
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        String code = createCode();
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject("[한다라트] 인증코드가 발송되었습니다.");
+            mimeMessageHelper.setText(setContent(code), true);
+            javaMailSender.send(mimeMessage);
+            codeSave(email, code);
+        } catch (MessagingException e) {
+            log.error("이메일 전송 실패 : {}", email);
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String createCode() {
+
+        SecureRandom secureRandom = new SecureRandom();
+        int authenticationCode = secureRandom.nextInt((int) Math.pow(10, 6));
+        return String.format("%06d", authenticationCode);
+    }
+
+    private String setContent(String code) {
+
+        Context context = new Context();
+        context.setVariable("code", code);
+
+        String content = templateEngine.process("change-password", context);
+
+        if (content == null || content.isEmpty()) {
+            throw new IllegalArgumentException("Generated content is empty");
+        }
+
+        return content;
+    }
+
+    private void codeSave(String email, String code) {
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set(PREFIX + email, code, 3, TimeUnit.MINUTES);
+    }
+}

--- a/src/main/java/com/org/candoit/domain/auth/service/EmailService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/EmailService.java
@@ -1,0 +1,26 @@
+package com.org.candoit.domain.auth.service;
+
+import com.org.candoit.domain.auth.dto.EmailRequest;
+import com.org.candoit.domain.member.entity.Member;
+import com.org.candoit.domain.member.entity.MemberStatus;
+import com.org.candoit.domain.member.exception.MemberErrorCode;
+import com.org.candoit.domain.member.repository.MemberRepository;
+import com.org.candoit.global.response.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final MemberRepository memberRepository;
+    private final EmailSenderService emailSenderService;
+
+    public void emailVerification(EmailRequest emailRequest) {
+        Member member = memberRepository.findByEmailAndMemberStatus(emailRequest.getEmail(),
+                MemberStatus.ACTIVITY)
+            .orElseThrow(() -> new CustomException(MemberErrorCode.NOT_FOUND_MEMBER));
+        emailSenderService.sendEmail(member.getEmail());
+    }
+
+}

--- a/src/main/java/com/org/candoit/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/org/candoit/domain/auth/service/EmailVerificationService.java
@@ -1,0 +1,41 @@
+package com.org.candoit.domain.auth.service;
+
+import com.org.candoit.domain.auth.dto.VerifyCodeRequest;
+import com.org.candoit.domain.auth.exception.AuthErrorCode;
+import com.org.candoit.global.response.CustomException;
+import java.util.concurrent.TimeUnit;
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Service;
+
+@AllArgsConstructor
+@Service
+public class EmailVerificationService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    static final String PREFIX = "auth:email:";
+
+    public void verifyCode(VerifyCodeRequest verifyCodeRequest) {
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+
+        String email = verifyCodeRequest.getEmail();
+        String code = verifyCodeRequest.getCode();
+
+        String correctCode = valueOperations.get(PREFIX + email);
+
+        if (correctCode == null) {
+            throw new CustomException(AuthErrorCode.INVALID_AUTH_CODE);
+        } else if (!correctCode.equals(code)) {
+            throw new CustomException(AuthErrorCode.NOT_MATCH_AUTH_CODE);
+        } else {
+            redisTemplate.delete(PREFIX + email);
+
+            // 인증된 사용자 저장
+            String newPrefix = PREFIX + "new-password:";
+            valueOperations.set(newPrefix + email, "authenticated", 10,
+                TimeUnit.MINUTES);
+        }
+    }
+}

--- a/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
+++ b/src/main/java/com/org/candoit/domain/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.org.candoit.domain.member.dto.MyPageResponse;
 import com.org.candoit.domain.member.dto.NewPasswordRequest;
 import com.org.candoit.domain.member.entity.Member;
 import com.org.candoit.domain.member.service.MemberService;
+import com.org.candoit.domain.member.service.ResetPasswordRequest;
 import com.org.candoit.global.annotation.LoginMember;
 import com.org.candoit.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -30,44 +31,63 @@ public class MemberController {
     private final MemberService memberService;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(@Parameter(hidden = true) @LoginMember Member loginMember){
+    public ResponseEntity<ApiResponse<MyPageResponse>> getMyPage(
+        @Parameter(hidden = true) @LoginMember Member loginMember) {
         MyPageResponse myPageResponse = memberService.getMyPage(loginMember.getMemberId());
         return ResponseEntity.ok(ApiResponse.success(myPageResponse));
     }
 
     @PostMapping("/join")
-    public ResponseEntity<ApiResponse<Object>> join(@Valid @RequestBody MemberJoinRequest memberJoinRequest){
+    public ResponseEntity<ApiResponse<Object>> join(
+        @Valid @RequestBody MemberJoinRequest memberJoinRequest) {
         memberService.join(memberJoinRequest);
         return ResponseEntity.ok(ApiResponse.successWithoutData());
     }
 
     @PostMapping("/check")
-    public ResponseEntity<ApiResponse<Boolean>> check(@Valid @RequestBody MemberCheckRequest memberCheckRequest){
+    public ResponseEntity<ApiResponse<Boolean>> check(
+        @Valid @RequestBody MemberCheckRequest memberCheckRequest) {
         Boolean result = memberService.check(memberCheckRequest);
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
     @PatchMapping
-    public ResponseEntity<ApiResponse<MyPageResponse>> updateMemberInfo(@Parameter(hidden = true) @LoginMember Member loginMember, @Valid @RequestBody MemberUpdateRequest memberUpdateRequest){
-        MyPageResponse myPageResponse = memberService.updateInfo(loginMember.getMemberId(), memberUpdateRequest);
+    public ResponseEntity<ApiResponse<MyPageResponse>> updateMemberInfo(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @Valid @RequestBody MemberUpdateRequest memberUpdateRequest) {
+        MyPageResponse myPageResponse = memberService.updateInfo(loginMember.getMemberId(),
+            memberUpdateRequest);
         return ResponseEntity.ok(ApiResponse.success(myPageResponse));
     }
 
     @DeleteMapping
-    public ResponseEntity<ApiResponse<Object>> withdraw(@Parameter(hidden = true) @LoginMember Member loginMember, @Valid @RequestBody CheckPasswordRequest checkPasswordRequest){
+    public ResponseEntity<ApiResponse<Object>> withdraw(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @Valid @RequestBody CheckPasswordRequest checkPasswordRequest) {
         memberService.withdraw(loginMember.getMemberId(), checkPasswordRequest);
         return ResponseEntity.ok(ApiResponse.successWithoutData());
     }
 
     @PostMapping("password-check")
-    public ResponseEntity<ApiResponse<Object>> checkCorrectPassword(@Parameter(hidden = true) @LoginMember Member loginMember, @Valid @RequestBody CheckPasswordRequest checkPasswordRequest){
+    public ResponseEntity<ApiResponse<Object>> checkCorrectPassword(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @Valid @RequestBody CheckPasswordRequest checkPasswordRequest) {
         memberService.checkPassword(loginMember, checkPasswordRequest);
         return ResponseEntity.ok(ApiResponse.successWithoutData());
     }
 
     @PatchMapping("/change-password")
-    public ResponseEntity<ApiResponse<Object>> updatePassword(@Parameter(hidden = true) @LoginMember Member loginMember, @RequestBody NewPasswordRequest newPasswordRequest){
+    public ResponseEntity<ApiResponse<Object>> updatePassword(
+        @Parameter(hidden = true) @LoginMember Member loginMember,
+        @RequestBody NewPasswordRequest newPasswordRequest) {
         memberService.updatePassword(loginMember.getMemberId(), newPasswordRequest);
         return ResponseEntity.ok(ApiResponse.successWithoutData());
+    }
+
+    @PostMapping("/new-password")
+    public ResponseEntity<ApiResponse<Boolean>> newPassword(
+        @RequestBody ResetPasswordRequest resetPasswordRequest) {
+        Boolean result = memberService.resetPassword(resetPasswordRequest);
+        return ResponseEntity.ok(ApiResponse.success(result));
     }
 }

--- a/src/main/java/com/org/candoit/domain/member/service/ResetPasswordRequest.java
+++ b/src/main/java/com/org/candoit/domain/member/service/ResetPasswordRequest.java
@@ -1,0 +1,11 @@
+package com.org.candoit.domain.member.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ResetPasswordRequest {
+    private String email;
+    private String newPassword;
+}

--- a/src/main/java/com/org/candoit/global/config/AsyncConfig.java
+++ b/src/main/java/com/org/candoit/global/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.org.candoit.global.config;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "mailExecutor")
+    public Executor asyncExecutor() {
+        final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(16);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("mailAsyncExecutor-");
+        executor.setRejectedExecutionHandler(new CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/org/candoit/global/config/EmailConfig.java
+++ b/src/main/java/com/org/candoit/global/config/EmailConfig.java
@@ -1,0 +1,55 @@
+package com.org.candoit.global.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+    @Value("${spring.mail.smtp.host}")
+    private String host;
+
+    @Value("${spring.mail.smtp.port}")
+    private int port;
+
+    @Value("${spring.mail.smtp.username}")
+    private String username;
+
+    @Value("${spring.mail.smtp.password}")
+    private String password;
+
+    @Value("${spring.mail.smtp.properties.mail.smtp.auth}")
+    private boolean auth;
+
+    @Value("${spring.mail.smtp.properties.mail.smtp.starttls.enable}")
+    private boolean starttlsEnable;
+
+    @Value("${spring.mail.smtp.properties.mail.smtp.starttls.required}")
+    private boolean starttlsRequired;
+
+    @Bean
+    public JavaMailSender javaMailSender() {
+        JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+        mailSender.setHost(host);
+        mailSender.setPort(port);
+        mailSender.setUsername(username);
+        mailSender.setPassword(password);
+        mailSender.setDefaultEncoding("UTF-8");
+        mailSender.setJavaMailProperties(getProperties());
+
+        return mailSender;
+    }
+
+    private Properties getProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttlsEnable);
+        properties.put("mail.smtp.starttls.required", starttlsRequired);
+
+        return properties;
+    }
+}

--- a/src/main/java/com/org/candoit/global/config/SecurityConfig.java
+++ b/src/main/java/com/org/candoit/global/config/SecurityConfig.java
@@ -62,10 +62,11 @@ public class SecurityConfig {
                 .requestMatchers("/",
                     "/swagger-ui/**",
                     "/v3/api-docs/**").permitAll()
-                // 로그인, 회원가입, 토큰 재발행
+                // 로그인, 회원가입, 토큰 재발행, 비밀번호 재설정
                 .requestMatchers("/api/auth/login", "/api/members/join", "/api/auth/reissue",
-                    "/api/members/check"
-                    ).permitAll()
+                    "/api/members/check", "/api/auth/send-code", "/api/auth/verify-code",
+                    "/api/members/new-password"
+                ).permitAll()
                 .requestMatchers("/api/auth/logout", "/api/main-goals").hasRole("USER")
                 .anyRequest().authenticated()
             );

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -28,8 +28,9 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final Set<String> excludeAllPaths = Set.of(
         "/swagger-ui/**", "/v3/api-docs/**",
-        "/api/auth/login/**", "/api/members/join/**", "/api/auth/reissue/**",
-        "/api/members/check"
+        "/api/auth/login", "/api/members/join", "/api/auth/reissue",
+        "/api/members/check", "/api/auth/send-code", "/api/auth/verify-code",
+        "/api/members/new-password"
     );
 
     public JwtAuthorizationFilter(JwtUtil jwtUtil) {

--- a/src/main/resources/templates/change-password.html
+++ b/src/main/resources/templates/change-password.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>한다라트</title>
+</head>
+<body>
+<div style="margin:100px;">
+  <h1> 한다라트 HandaPlan</h1>
+  <hr style="color: #e8e8e8"><br>
+  <p> 안녕하세요. 한다라트입니다. <br>아래의 인증코드를 입력해주세요.</p>
+  <br>
+
+  <div align="center" style="border:2px solid #e8e8e8; font-family:verdana;">
+    <div style="font-size:130%; color:#7b14ba; padding: 20px" th:text="${code}"></div>
+  </div>
+  <br/>
+</div>
+
+
+</body>
+</html>


### PR DESCRIPTION
## 📌 이슈 번호
- #126 

## 👩🏻‍💻 구현 내용
### Problem
- 요구사항에 따라 이메일 인증 코드 발송/검증, 비밀번호 재설정 api가 필요

### Approach
**① 이메일 인증 코드 발송**
- 비동기로 코드를 작성하기 위해 repository에 해당 이메일을 검증하는 작업은 `emailService.emailVerification()`에서 진행. 이 후, 이메일 발송 작업은 `EmailSenderService`에서 진행.
- 이메일이 있는 경우, `mailSenderService.sendEmail()`이 실행.
- 생성한 인증 코드를 redis에 `key: auth:email:{email}`, `value: code`로 저장.

**①-1 인증 코드 생성**
- 인증 코드 생성 시, Random 클래스 대신 SecureRandom을 사용. 

**①-2 비동기 사용**
- 네트워크로 인해 지연될 수 있는 이메일 발송 기능을 비동기로 진행.

- `setCorePoolSize(4)` , `setMaxPoolSize(16)`, `setQueueCapacity(100)` 
  - 소규모 프로젝트이므로 스레드와 큐 용량을 작게 설정.

- `setThreadNamePrefix()`
  -  메일을 발송하는 스레드 명의 prefix를 `mailAsyncExecutor-`로 지정해 로그 확인이 쉽도록 함.

- `setRejectedExecutionHandler(new CallerRunsPolicy())`
  - 요청이 많은 상황에서 시스템이 안정적으로 실행될 수 있도록 함.

**② 인증 코드 검증**
- redis에 저장된 데이터와 비교해 유효한 요청인지 확인
- 인증된 사용자는 redis에 `key: auth:email:new-password:{email}`, `value: authenticated`로 **10분 간** 저장

**③ 비밀번호 재설정**
- redis에 인증된 사용자로 저장이 되어있는지 확인
- 인증된 사용자라면, 요청한 비밀번호로 변경하고, redis에 저장된 값을 삭제


### Learned
- Random은 현재 시간을 시드 값으로 예측 가능한 난수를 생성하는 반면, Secure는 예측 불가능한 시드 값을 사용해 보다 안전한 난수를 생성할 수 있다. 따라서, **보안성이 중요한 서비스 제공을 위해서는 SecureRandom을 사용**한다.
- CallerRunsPolicy()는 사용할 수 있는 스레드가 없고, 큐의 capacity도 모두 차있는 경우, 요청을 보내는 스레드가 직접 작업을 하게 된다.  ➜ 새로운 요청이 들어오는 속도가 줄어들어 시스템 부하를 완화할 수 있다.