### PR TITLE
fix: 프로필 이미지 응답 경로 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -130,7 +130,7 @@ public class MemberService {
             memberUpdateRequest.getComment(), memberUpdateRequest.getProfileImage());
 
         return MyPageResponse.builder()
-            .profileImage("https://" +cloudFrontDomain + updateMember.getProfilePath())
+            .profileImage("https://" +cloudFrontDomain+ "/" + updateMember.getProfilePath())
             .comment(updateMember.getComment())
             .email(updateMember.getEmail())
             .nickname(updateMember.getNickname())


### PR DESCRIPTION
## 📌 이슈 번호
- #128 
## 👩🏻‍💻 구현 내용
### Problem
- CDN domain과 key(파일명) 사이에 `/`가 없는 채로 응답되고 있어 해당 경로로 접근 시, 이미지가 나오지 않는다는 문제 발견
### Approach
**① 응답 값에 `/` 추가**
- 변경 전: "https://" + cloudFrontDomain + updateMember.getProfilePath()
- 변경 후: "https://" + cloudFrontDomain **+ "/" +** updateMember.getProfilePath()
### Result
- 접근 가능한 프로필 경로 제공