### PR TITLE
fix: 회원정보 조회 시, 프로필 이미지 경로 응답하도록 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/service/MemberService.java
+++ b/src/main/java/com/org/candoit/domain/member/service/MemberService.java
@@ -80,7 +80,7 @@ public class MemberService {
             MemberErrorCode.NOT_FOUND_MEMBER));
 
         return MyPageResponse.builder()
-            .profileImage(member.getProfilePath())
+            .profileImage("https://" +cloudFrontDomain+ "/" + member.getProfilePath())
             .comment(member.getComment())
             .email(member.getEmail())
             .nickname(member.getNickname())


### PR DESCRIPTION
## 📌 이슈 번호
- #131 

## 👩🏻‍💻 구현 내용
### Problem
- 프로필 조회 api에서 프로필 이미지 파일명만 반환해 정상적인 UI 출력이 이루어지지 않음.

### Approach
- 프로필 이미지 경로를 반환할 수 있도록 수정