### PR TITLE
fix: 로그인 응답에 포함된 프로필 이미지 값 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/member/dto/BasicMemberInfoResponse.java
+++ b/src/main/java/com/org/candoit/domain/member/dto/BasicMemberInfoResponse.java
@@ -5,10 +5,14 @@ import com.org.candoit.domain.member.entity.MemberStatus;
 import com.org.candoit.global.security.basic.CustomUserDetails;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.beans.factory.annotation.Value;
 
 @Setter
 @Getter
 public class BasicMemberInfoResponse {
+
+    @Value("${cloud.aws.cloudfront.domain}")
+    private String cloudFrontDomain;
 
     private Long memberId;
 
@@ -30,7 +34,7 @@ public class BasicMemberInfoResponse {
         this.email = customUserDetails.getMember().getEmail();
         this.nickname = customUserDetails.getMember().getNickname();
         this.comment = customUserDetails.getMember().getComment();
-        this.profilePath = customUserDetails.getMember().getProfilePath();
+        this.profilePath = "https://" +cloudFrontDomain+ "/" + customUserDetails.getMember().getProfilePath();
         this.memberStatus = customUserDetails.getMember().getMemberStatus();
         this.memberRole = customUserDetails.getMember().getMemberRole();
     }


### PR DESCRIPTION
## 📌 이슈 번호
- #131 

## 👩🏻‍💻 구현 내용
### Problem
- 기존에는 정확한 이미지 경로를 반환하지 않아 이미지 조회가 불가능했음.

### Approach
① DB에 저장되어 있는 경로와 cloudfront 도메인 경로를 합쳐 응답하도록 함.

### Result
- 정상적으로 이미지를 조회할 수 있음.
