### PR TITLE
fix: 홈화면-메인골리스트 조회 쿼리 수정

### DIFF
--- a/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
+++ b/src/main/java/com/org/candoit/domain/dailyprogress/controller/DailyProgressController.java
@@ -16,7 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,13 +23,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/sub-goals/{subGoalId}/daily-progress")
 @RequiredArgsConstructor
 public class DailyProgressController {
 
     private final DailyProgressService dailyProgressService;
 
-    @PutMapping("/sub-goals/{subGoalId}/daily-progress")
+    @PutMapping
     public ResponseEntity<ApiResponse<List<DetailProgressResponse>>> checkedDate(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId,
@@ -41,7 +40,7 @@ public class DailyProgressController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @GetMapping("/sub-goals/{subGoalId}/daily-progress")
+    @GetMapping
     public ResponseEntity<ApiResponse<List<DetailProgressResponse>>> getDailyProgress(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId
@@ -51,7 +50,7 @@ public class DailyProgressController {
         return ResponseEntity.ok(ApiResponse.success(result));
     }
 
-    @GetMapping("/sub-goals/{subGoalId}/daily-progress/calendar")
+    @GetMapping("/calendar")
     public ResponseEntity<ApiResponse<DailyProgressResponse>> getDailyProgressCalendar(
         @Parameter(hidden = true) @LoginMember Member loginMember,
         @PathVariable Long subGoalId, @RequestParam LocalDate date,

--- a/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
+++ b/src/main/java/com/org/candoit/domain/maingoal/repository/MainGoalCustomRepositoryImpl.java
@@ -65,7 +65,7 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             ))
             .from(mainGoal)
             .where((mainGoal.member.memberId.eq(memberId)).and(
-                mainGoal.mainGoalStatus.in(MainGoalStatus.ACTIVITY, MainGoalStatus.ATTAINMENT)))
+                mainGoal.mainGoalStatus.eq(MainGoalStatus.ACTIVITY)))
             .fetch();
     }
 
@@ -83,7 +83,7 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             .from(mainGoal)
             .where(mainGoal.member.memberId.eq(memberId)
                 .and(
-                    mainGoal.mainGoalStatus.in(MainGoalStatus.ACTIVITY, MainGoalStatus.ATTAINMENT)))
+                    mainGoal.mainGoalStatus.eq(MainGoalStatus.ACTIVITY)))
             .orderBy(mainGoal.mainGoalId.asc())
             .fetchFirst());
     }
@@ -95,8 +95,7 @@ public class MainGoalCustomRepositoryImpl implements MainGoalCustomRepository {
             .where(
                 mainGoal.member.memberId.eq(memberId)
                     .and(
-                        mainGoal.mainGoalStatus.in(MainGoalStatus.ACTIVITY,
-                            MainGoalStatus.ATTAINMENT)))
+                        mainGoal.mainGoalStatus.eq(MainGoalStatus.ACTIVITY)))
             .fetchFirst();
         return searchResult != null;
     }

--- a/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/org/candoit/global/security/filter/JwtAuthorizationFilter.java
@@ -28,7 +28,7 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final Set<String> excludeAllPaths = Set.of(
         "/swagger-ui/**", "/v3/api-docs/**",
-        "/api/auth/login", "/api/members/join", "/api/auth/reissue",
+        "/api/auth/login", "/api/members/join",
         "/api/members/check", "/api/auth/send-code", "/api/auth/verify-code",
         "/api/members/new-password"
     );


### PR DESCRIPTION
## 📌 이슈 번호
- #138 

## 👩🏻‍💻 구현 내용
### Problem
- 홈화면에서 메인골 리스트 조회하는 경우, activity 상태의 메인골만 반환해야 함.
- 그러나, attainment 상태의 메인골도 함께 반환하고 있음.

### Approach
- 쿼리 수정
- `mainGoal.mainGoalStatus.in(MainGoalStatus.ACTIVITY, MainGoalStatus.ATTAINMENT)))` ➡ `mainGoal.mainGoalStatus.eq(MainGoalStatus.ACTIVITY)))`